### PR TITLE
Bug: remove try/except blocks so we fail if there are issues

### DIFF
--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -143,15 +143,11 @@ class SearchCountStreamBase(GitHubGraphqlStream):
         return []
 
     def _get_bookmark_for_context(self, context: dict) -> str | None:
-        try:
-            stream_state = self.tap.state.get("bookmarks", {}).get(self.name, {})
-            for partition_state in stream_state.get("partitions", []):
-                state_context = partition_state.get("context", {})
-                if state_context.get("org") == context.get("org") and state_context.get("repo") == context.get("repo"):
-                    return partition_state.get("replication_key_value")
-            return None
-        except Exception:
-            return None
+        stream_state = self.tap.state.get("bookmarks", {}).get(self.name, {})
+        for partition_state in stream_state.get("partitions", []):
+            state_context = partition_state.get("context", {})
+            if state_context.get("org") == context.get("org") and state_context.get("repo") == context.get("repo"):
+                return partition_state.get("replication_key_value")
 
     def _should_include_month(self, month_str: str, bookmark_date: date | None) -> bool:
         month_date = month_to_date(month_str)
@@ -257,14 +253,11 @@ class SearchCountStreamBase(GitHubGraphqlStream):
                 self.logger.warning(f"Batch failed, falling back to individual queries: {str(e)}")
                 # Fallback to individual queries
                 for repo in batch_repos:
-                    try:
-                        query = self._build_repo_query(org, repo, rest_query)
-                        count = self._search_aggregate_count(query, api_url_base)
-                        if count > 0:
-                            repo_counts[repo] = count
-                    except Exception:
-                        continue
-                
+                    query = self._build_repo_query(org, repo, rest_query)
+                    count = self._search_aggregate_count(query, api_url_base)
+                    if count > 0:
+                        repo_counts[repo] = count
+                    
         return repo_counts
 
     def _search_aggregate_count_batch(self, queries: list[str], api_url_base: str) -> list[int]:
@@ -484,12 +477,7 @@ def _decode_search_config(tap) -> dict | None:
     """Simple configuration loading from environment variable."""
     search_json = os.getenv("TAP_GITHUB_SEARCH_STATS_SEARCH")
     if search_json:
-        try:
-            return json.loads(search_json)
-        except Exception as e:
-            tap.logger.warning(f"Failed to parse search config JSON: {e}")
-    
-    return None
+        return json.loads(search_json)
 
 
 def create_configurable_streams(tap, config_override: dict | None = None) -> list:

--- a/tap_github_search/tests/test_search_count_streams.py
+++ b/tap_github_search/tests/test_search_count_streams.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from datetime import date
 import os
+import types
 import logging
 from unittest.mock import Mock, patch
 import pytest
+import requests
 
 from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
@@ -179,6 +181,7 @@ def test_configurable_stream_partitions_with_orgs():
     }
     mock_tap = Mock()
     mock_tap.config = {}
+    mock_tap.state = {}
     
     search_config = {
         "search": {
@@ -210,6 +213,7 @@ def test_configurable_stream_partitions_with_repos():
     }
     mock_tap = Mock()
     mock_tap.config = {}
+    mock_tap.state = {}
     
     search_config = {
         "search": {


### PR DESCRIPTION
Removing try/except blocks so we fail explicitly if there are issues.

### Testing
```bash
mahangu@galactica tap-github % test_venv/bin/pytest -q tap_github_search/tests/
/Users/mahangu/a8c/tap-github/test_venv/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
..................s.....                                                                                                                                         [100%]
23 passed, 1 skipped in 0.07s
```

Tested with Meltano test script as well.