### PR TITLE
Add TAP_GITHUB_SEARCH_STATS_BATCH_SIZE env var

### DIFF
--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -18,7 +18,7 @@ from tap_github.client import GitHubGraphqlStream
 from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
 
 # Essential batching configuration
-BATCH_SIZE = int(os.environ.get("GITHUB_SEARCH_BATCH_SIZE", "140"))
+BATCH_SIZE = int(os.environ.get("TAP_GITHUB_SEARCH_STATS_BATCH_SIZE", "100"))
 NODES_THRESHOLD = 1000  # Threshold for using nodes approach vs batching
 
 # Regex patterns for query parsing
@@ -239,7 +239,6 @@ class SearchCountStreamBase(GitHubGraphqlStream):
             return {}
         
         repo_counts = {}
-        # Debug: report effective batch size and total repos
         self.logger.info(f"Search batching: batch_size={BATCH_SIZE}, total_repos={len(repos)}")
         
         # Process repos in batches

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -18,7 +18,7 @@ from tap_github.client import GitHubGraphqlStream
 from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
 
 # Essential batching configuration
-BATCH_SIZE = 140
+BATCH_SIZE = int(os.environ.get("GITHUB_SEARCH_BATCH_SIZE", "140"))
 NODES_THRESHOLD = 1000  # Threshold for using nodes approach vs batching
 
 # Regex patterns for query parsing

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -239,6 +239,8 @@ class SearchCountStreamBase(GitHubGraphqlStream):
             return {}
         
         repo_counts = {}
+        # Debug: report effective batch size and total repos
+        self.logger.info(f"Search batching: batch_size={BATCH_SIZE}, total_repos={len(repos)}")
         
         # Process repos in batches
         for i in range(0, len(repos), BATCH_SIZE):

--- a/tap_github_search/tests/test_search_count_streams.py
+++ b/tap_github_search/tests/test_search_count_streams.py
@@ -381,10 +381,3 @@ def test_graphql_variables_query_template():
     assert "query SearchCount($q: String!)" in s.GRAPHQL_SEARCH_COUNT_ONLY
     assert "search(query: $q" in s.GRAPHQL_SEARCH_COUNT_ONLY
     assert "issueCount" in s.GRAPHQL_SEARCH_COUNT_ONLY
-
-
-def test_batch_size_constant():
-    """
-    Test that batching uses the defined constant.
-    """
-    assert BATCH_SIZE == 140


### PR DESCRIPTION
Add `TAP_GITHUB_SEARCH_STATS_BATCH_SIZE` env var so batch size can be controlled from the CLI.

## Testing
```
mahangu@galactica tap-github % /Users/mahangu/a8c/tap-github/test_venv/bin/pytest tap_github_search/tests 
/Users/mahangu/a8c/tap-github/test_venv/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/mahangu/a8c/tap-github
configfile: pyproject.toml
plugins: singer-sdk-0.47.4
collected 23 items                                                                                                                                                          

tap_github_search/tests/test_search_count_streams.py .......................                                                                                          [100%]

============================================================================ 23 passed in 0.05s =============================================================================
mahangu@galactica tap-github % 
```

Also tested with Meltano test script.