### PR TITLE
hotfix: add support for base64 encoded config to avoid YARN shell escaping issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-github-search"
-version = "0.0.9"
+version = "0.0.10"
 description = "Singer tap for GitHub, built with the Singer SDK."
 authors = ["Meltano and Meltano Community <hello@meltano.com>"]
 maintainers = [

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -477,7 +477,7 @@ def validate_stream_config(stream_config: dict) -> list[str]:
 
 def _decode_search_config(tap) -> dict | None:
     """Simple configuration loading from environment variable."""
-    search_json = os.getenv("TAP_GITHUB_SEARCH_SEARCH")
+    search_json = os.getenv("TAP_GITHUB_SEARCH_CONFIG")
     if search_json:
         return json.loads(search_json)
 

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -18,7 +18,7 @@ from tap_github.client import GitHubGraphqlStream
 from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
 
 # Essential batching configuration
-BATCH_SIZE = int(os.environ.get("TAP_GITHUB_SEARCH_STATS_BATCH_SIZE", "100"))
+BATCH_SIZE = int(os.environ.get("TAP_GITHUB_SEARCH_BATCH_SIZE", "100"))
 NODES_THRESHOLD = 1000  # Threshold for using nodes approach vs batching
 
 # Regex patterns for query parsing
@@ -477,7 +477,7 @@ def validate_stream_config(stream_config: dict) -> list[str]:
 
 def _decode_search_config(tap) -> dict | None:
     """Simple configuration loading from environment variable."""
-    search_json = os.getenv("TAP_GITHUB_SEARCH_STATS_SEARCH")
+    search_json = os.getenv("TAP_GITHUB_SEARCH_SEARCH")
     if search_json:
         return json.loads(search_json)
 

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import base64
 import json
 import os
 from singer_sdk import Stream
@@ -13,9 +14,17 @@ class TapGitHubSearch(TapGitHub):
     name = "tap-github-search"
 
     def discover_streams(self) -> list[Stream]:
+        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_STATS_SEARCH_B64")
         search_cfg = os.environ.get("GITHUB_SEARCH_CONFIG")
+        
+        if search_cfg_b64:
+            try:
+                search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
+            except Exception as e:
+                raise ValueError(f"Failed to decode TAP_GITHUB_SEARCH_STATS_SEARCH_B64: {e}")
+        
         if not search_cfg and "search" not in self.config:
-            raise ValueError("Provide search.* in config or set GITHUB_SEARCH_CONFIG.")
+            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_STATS_SEARCH_B64.")
 
         cfg = dict(self.config)
         if "search" not in cfg and search_cfg:

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -18,10 +18,7 @@ class TapGitHubSearch(TapGitHub):
         search_cfg = os.environ.get("GITHUB_SEARCH_CONFIG")
         
         if search_cfg_b64:
-            try:
-                search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
-            except Exception as e:
-                raise ValueError(f"Failed to decode TAP_GITHUB_SEARCH_STATS_SEARCH_B64: {e}")
+            search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
         
         if not search_cfg and "search" not in self.config:
             raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_STATS_SEARCH_B64.")

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -14,14 +14,19 @@ class TapGitHubSearch(TapGitHub):
     name = "tap-github-search"
 
     def discover_streams(self) -> list[Stream]:
-        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_SEARCH_B64")
+        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_CONFIG_B64")
         search_cfg = os.environ.get("GITHUB_SEARCH_CONFIG")
+        
+        # Ensure both env vars aren't set simultaneously
+        if search_cfg_b64 and search_cfg:
+            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG_B64 and GITHUB_SEARCH_CONFIG are set. Please use only one.")
         
         if search_cfg_b64:
             search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
+            self.logger.debug(f"Decoded TAP_GITHUB_SEARCH_CONFIG_B64: {search_cfg}")
         
         if not search_cfg and "search" not in self.config:
-            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_SEARCH_B64.")
+            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_CONFIG_B64.")
 
         cfg = dict(self.config)
         if "search" not in cfg and search_cfg:

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -14,14 +14,14 @@ class TapGitHubSearch(TapGitHub):
     name = "tap-github-search"
 
     def discover_streams(self) -> list[Stream]:
-        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_STATS_SEARCH_B64")
+        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_SEARCH_B64")
         search_cfg = os.environ.get("GITHUB_SEARCH_CONFIG")
         
         if search_cfg_b64:
             search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
         
         if not search_cfg and "search" not in self.config:
-            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_STATS_SEARCH_B64.")
+            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_SEARCH_B64.")
 
         cfg = dict(self.config)
         if "search" not in cfg and search_cfg:

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -15,18 +15,18 @@ class TapGitHubSearch(TapGitHub):
 
     def discover_streams(self) -> list[Stream]:
         search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_CONFIG_B64")
-        search_cfg = os.environ.get("GITHUB_SEARCH_CONFIG")
+        search_cfg = os.environ.get("TAP_GITHUB_SEARCH_CONFIG")
         
         # Ensure both env vars aren't set simultaneously
         if search_cfg_b64 and search_cfg:
-            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG_B64 and GITHUB_SEARCH_CONFIG are set. Please use only one.")
+            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG_B64 and TAP_GITHUB_SEARCH_CONFIG are set. Please use only one.")
         
         if search_cfg_b64:
             search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
             self.logger.debug(f"Decoded TAP_GITHUB_SEARCH_CONFIG_B64: {search_cfg}")
         
         if not search_cfg and "search" not in self.config:
-            raise ValueError("Provide search.* in config, set GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_CONFIG_B64.")
+            raise ValueError("Provide search.* in config, set TAP_GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_CONFIG_B64.")
 
         cfg = dict(self.config)
         if "search" not in cfg and search_cfg:

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -19,13 +19,13 @@ class TapGitHubSearch(TapGitHub):
         
         # Ensure both env vars aren't set simultaneously
         if search_cfg_b64 and search_cfg:
-            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG_B64 and TAP_GITHUB_SEARCH_CONFIG are set. Please use only one.")
+            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG and TAP_GITHUB_SEARCH_CONFIG_B64 are set. Please use only one.")
         
         if search_cfg_b64:
             search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
             self.logger.debug(f"Decoded TAP_GITHUB_SEARCH_CONFIG_B64: {search_cfg}")
         
-        if not search_cfg and "search" not in self.config:
+        if not search_cfg and not search_cfg_b64 and "search" not in self.config:
             raise ValueError("Provide search.* in config, set TAP_GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_CONFIG_B64.")
 
         cfg = dict(self.config)


### PR DESCRIPTION
Adding a quick fix `TAP_GITHUB_SEARCH_SEARCH_B64` env var to bypass YARN shell escaping issues.

Tested in internal PR.