### PR TITLE
[STR-309] Add the `request_decorator` for handling request failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-github-search"
-version = "0.0.10"
+version = "0.0.11"
 description = "Singer tap for GitHub, built with the Singer SDK."
 authors = ["Meltano and Meltano Community <hello@meltano.com>"]
 maintainers = [

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -68,7 +68,8 @@ class SearchCountStreamBase(GitHubGraphqlStream):
         """Make a GraphQL request with standardized payload building."""
         payload = self._build_graphql_payload(query_template, variables)
         prepared_request = self.build_prepared_request(method="POST", url=f"{api_url_base}/graphql", json=payload)
-        return self._request(prepared_request, None)
+        decorated_request = self.request_decorator(self._request)
+        return decorated_request(prepared_request, None)
 
     def _filter_active_repos(self, repos: list[dict[str, Any]]) -> list[str]:
         """Filter out forks and archived repos, return list of active repo names."""


### PR DESCRIPTION
The `_request` when used directly ignores any retriable exceptions (like `RetriableAPIError` for rate limits). The `request_decorator` instantiates a decorator for handling request failures by the Meltano SDK.

```python
    def request_decorator(self, func: t.Callable) -> t.Callable:
        """Instantiate a decorator for handling request failures.

        Uses a wait generator defined in `backoff_wait_generator` to
        determine backoff behaviour. Try limit is defined in
        `backoff_max_tries`, and will trigger the event defined in
        `backoff_handler` before retrying. Developers may override one or
        all of these methods to provide custom backoff or retry handling.

        Args:
            func: Function to decorate.

        Returns:
            A decorated method.
        """
```

`backoff_max_tries` default is 5 and there is already implemented the `backoff_handler` (to try a different token) and also for the secondary rate limits there is a sleep already defined in the code:

https://github.com/Automattic/tap-github-search/blob/a15836d1b1824829e0fc03c3076c5a3b0e3e0e94/tap_github/client.py#L242-L243