### PR TITLE
Add per-PR PR-velocity stream (mode: pr_velocity)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,11 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      PACKAGE_VERSION: ${{ needs.build.outputs.version }}
     environment:
       name: pypi
-      url: https://pypi.org/project/meltanolabs-tap-github/${{ needs.build.outputs.version }}
+      url: https://pypi.org/project/tap-github-search/${{ env.PACKAGE_VERSION }}
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:

--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -8,6 +8,7 @@ on:
     - poetry.lock
     - pyproject.toml
     - 'tap_github/**'
+    - 'tap_github_search/**'
   push:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
     - poetry.lock
     - pyproject.toml
     - 'tap_github/**'
+    - 'tap_github_search/**'
   workflow_dispatch:
   schedule:
   # Every 6 hours
@@ -86,7 +88,7 @@ jobs:
       id: type_check
       continue-on-error: true
       run: |
-        poetry run mypy tap_github
+        poetry run mypy tap_github tap_github_search
     - name: Test with pytest
       id: test_pytest
       continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -91,6 +91,42 @@ tap-github --help
 tap-github --config CONFIG --discover > ./catalog.json
 ```
 
+## tap-github-search Wrapper Config
+
+This wrapper adds a top-level `search` config block on top of upstream `tap-github`:
+
+```yaml
+search:
+  scope:
+    api_url_base: https://api.github.com      # or https://github.a8c.com/api/v3 (GHES)
+    instance: github_com                       # github_com | a8c_ghe | tumblr_ghe
+    orgs: [Automattic]
+    breakdown: repo                            # optional; count streams only
+  backfill:
+    start_month: "2026-02"
+  streams:
+    - name: pr_velocity
+      mode: pr_velocity                        # one row per closed PR; omit for the count stream
+      query_template: "org:{org} type:pr is:closed closed:{start}..{end}"
+      markers: ['"Generated with Claude Code"']  # body markers → is_ai_authored
+      reviewer_clause: "commenter:claude[bot]"   # search suffix → is_ai_reviewed
+```
+
+For SSRF defense-in-depth, `api_url_base` is checked against an allowlist
+(`api.github.com`, `github.a8c.com`, `github.tumblr.net`) at both config-load
+and authenticator-emit time. Add a host to `VALID_API_HOSTS` in
+`tap_github_search/search_count_streams.py` if you legitimately need another.
+
+### Tap-specific environment knobs
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TAP_GITHUB_SEARCH_AUTH_TOKEN` | (required) | GitHub Personal Access Token |
+| `TAP_GITHUB_SEARCH_CONFIG_B64` | — | Base64-encoded `search` config, overrides `meltano.yml` |
+| `TAP_GITHUB_SEARCH_BATCH_SIZE` | 100 | GraphQL page size for count streams |
+| `TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES` | 5 | Outer retry attempts on transient 5xx/INTERNAL in `pr_velocity` |
+| `TAP_GITHUB_SEARCH_VELOCITY_MAX_WALL_SECONDS` | 180 | Wall-time budget per `_robust_graphql` call (pr_velocity) |
+
 ## Contributing
 This project uses parent-child streams. Learn more about them [here.](https://gitlab.com/meltano/sdk/-/blob/main/docs/parent_streams.md)
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ search:
     - name: pr_velocity
       mode: pr_velocity                        # one row per closed PR; omit for the count stream
       query_template: "org:{org} type:pr is:closed closed:{start}..{end}"
-      markers: ['"Generated with Claude Code"']  # body markers → is_ai_authored
-      reviewer_clause: "commenter:claude[bot]"   # search suffix → is_ai_reviewed
+      markers: ['"Generated with Claude Code"']  # PR body markers -> is_ai_authored
+      reviewer_clause: "reviewed-by:claude[bot]" # search suffix -> is_ai_reviewed
 ```
+
+`pr_velocity` requires a PR-only `closed:{start}..{end}` query template so it
+can split large months safely. `markers` are matched locally against the PR body
+only; use quotes when a marker should be treated as one literal phrase.
+`reviewer_clause` remains a GitHub search suffix, so use `reviewed-by:` for PR
+reviews or a deliberate `commenter:`/phrase clause when comments are the signal.
 
 For SSRF defense-in-depth, `api_url_base` is checked against an allowlist
 (`api.github.com`, `github.a8c.com`, `github.tumblr.net`) at both config-load
@@ -121,9 +127,9 @@ and authenticator-emit time. Add a host to `VALID_API_HOSTS` in
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `TAP_GITHUB_SEARCH_AUTH_TOKEN` | (required) | GitHub Personal Access Token |
+| `TAP_GITHUB_SEARCH_AUTH_TOKEN` | (required unless `auth_token`/`GITHUB_TOKEN*` is set) | GitHub Personal Access Token |
 | `TAP_GITHUB_SEARCH_CONFIG_B64` | — | Base64-encoded `search` config, overrides `meltano.yml` |
-| `TAP_GITHUB_SEARCH_BATCH_SIZE` | 100 | GraphQL page size for count streams |
+| `TAP_GITHUB_SEARCH_BATCH_SIZE` | 100 | Repo-count batch size for count streams |
 | `TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES` | 5 | Outer retry attempts on transient 5xx/INTERNAL in `pr_velocity` |
 | `TAP_GITHUB_SEARCH_VELOCITY_MAX_WALL_SECONDS` | 180 | Wall-time budget per `_robust_graphql` call (pr_velocity) |
 
@@ -181,9 +187,9 @@ Now you can test and orchestrate using Meltano:
 
 ```bash
 # Test invocation:
-meltano invoke tap-github --version
+meltano invoke tap-github-search --version
 # OR run a test `elt` pipeline:
-meltano elt tap-github target-jsonl
+meltano elt tap-github-search target-jsonl
 ```
 
 One-liner to recreate output directory, run elt, and write out state file:

--- a/meltano.yml
+++ b/meltano.yml
@@ -5,8 +5,9 @@ venv:
   backend: uv
 plugins:
   extractors:
-  - name: tap-github
-    namespace: tap_github
+  - name: tap-github-search
+    namespace: tap_github_search
+    executable: tap-github-search
     pip_url: -e .
     capabilities:
     - state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-github-search"
-version = "0.0.12"
+version = "0.0.13"
 description = "Singer tap for GitHub, built with the Singer SDK."
 authors = ["Meltano and Meltano Community <hello@meltano.com>"]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-github-search"
-version = "0.0.11"
+version = "0.0.12"
 description = "Singer tap for GitHub, built with the Singer SDK."
 authors = ["Meltano and Meltano Community <hello@meltano.com>"]
 maintainers = [

--- a/tap_github_search/authenticator.py
+++ b/tap_github_search/authenticator.py
@@ -1,20 +1,27 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
 
 import requests
 
 from tap_github.authenticator import (
+    AppTokenManager,
     GitHubTokenAuthenticator,
     TokenManager,
 )
+from tap_github_search.github_hosts import normalize_api_base_url
 
 
 class GHEPersonalTokenManager(TokenManager):
     """TokenManager that validates against a given API base URL (GHE-aware)."""
 
-    def __init__(self, token: str, api_base_url: str, rate_limit_buffer: int | None = None, logger: Any | None = None) -> None:
+    def __init__(
+        self,
+        token: str,
+        api_base_url: str,
+        rate_limit_buffer: int | None = None,
+        logger: Any | None = None,
+    ) -> None:
         super().__init__(token, rate_limit_buffer=rate_limit_buffer, logger=logger)
         self.api_base_url = api_base_url.rstrip("/")
 
@@ -76,21 +83,7 @@ class WrapperGitHubTokenAuthenticator(GitHubTokenAuthenticator):
                 )
         except Exception:
             pass
-        api_base_url = api_base_url.rstrip("/")
-
-        # Defense-in-depth: re-validate against the SSRF allowlist before the
-        # authenticator ever emits the PAT to this host. validate_scope() in
-        # create_configurable_streams gates the normal flow; this gate covers
-        # paths that construct a stream without going through that factory.
-        # Lazy import to avoid the circular (search_count_streams imports us).
-        from tap_github_search.search_count_streams import VALID_API_HOSTS
-        host = urlparse(api_base_url).hostname
-        if host not in VALID_API_HOSTS:
-            raise ValueError(
-                f"Refusing to authenticate to {host!r}: not in "
-                f"VALID_API_HOSTS {sorted(VALID_API_HOSTS)}"
-            )
-        return api_base_url
+        return normalize_api_base_url(api_base_url)
 
     def prepare_tokens(self) -> list[TokenManager]:  # type: ignore[override]
         env_dict = self.get_env()
@@ -101,6 +94,8 @@ class WrapperGitHubTokenAuthenticator(GitHubTokenAuthenticator):
         personal_tokens: set[str] = set()
         if "auth_token" in self._config:
             personal_tokens.add(self._config["auth_token"])
+        if "TAP_GITHUB_SEARCH_AUTH_TOKEN" in env_dict:
+            personal_tokens.add(env_dict["TAP_GITHUB_SEARCH_AUTH_TOKEN"])
         if "additional_auth_tokens" in self._config:
             personal_tokens = personal_tokens.union(self._config["additional_auth_tokens"])
         else:
@@ -124,13 +119,33 @@ class WrapperGitHubTokenAuthenticator(GitHubTokenAuthenticator):
             else:
                 self.logger.warning("A token was dismissed.")
 
-        # App tokens: fall back to parent behavior which contacts api.github.com
-        # This is acceptable for now; can be extended if needed for GHE app tokens.
+        app_keys: set[str] = set()
+        if "auth_app_keys" in self._config:
+            app_keys = app_keys.union(self._config["auth_app_keys"])
+        elif "GITHUB_APP_PRIVATE_KEY" in env_dict:
+            app_keys.add(env_dict["GITHUB_APP_PRIVATE_KEY"])
+
+        if app_keys and self._api_base_url != "https://api.github.com":
+            raise ValueError(
+                "GitHub App authentication is only supported for public GitHub "
+                "in tap-github-search. Use PAT auth for GitHub Enterprise."
+            )
+
         app_token_managers: list[TokenManager] = []
-        try:
-            app_token_managers = super().prepare_tokens()[len(personal_token_managers) :]
-        except Exception:
-            pass
+        for app_key in app_keys:
+            try:
+                app_token_manager = AppTokenManager(
+                    app_key,
+                    rate_limit_buffer=rate_limit_buffer,
+                    expiry_time_buffer=expiry_time_buffer,
+                    logger=self.logger,
+                )
+                if app_token_manager.is_valid_token():
+                    app_token_managers.append(app_token_manager)
+            except ValueError as exc:
+                self.logger.warning(
+                    f"An error was thrown while preparing an app token: {exc}"
+                )
 
         self.logger.info(
             f"Tap will run with {len(personal_token_managers)} personal auth tokens "

--- a/tap_github_search/authenticator.py
+++ b/tap_github_search/authenticator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
@@ -75,7 +76,21 @@ class WrapperGitHubTokenAuthenticator(GitHubTokenAuthenticator):
                 )
         except Exception:
             pass
-        return api_base_url.rstrip("/")
+        api_base_url = api_base_url.rstrip("/")
+
+        # Defense-in-depth: re-validate against the SSRF allowlist before the
+        # authenticator ever emits the PAT to this host. validate_scope() in
+        # create_configurable_streams gates the normal flow; this gate covers
+        # paths that construct a stream without going through that factory.
+        # Lazy import to avoid the circular (search_count_streams imports us).
+        from tap_github_search.search_count_streams import VALID_API_HOSTS
+        host = urlparse(api_base_url).hostname
+        if host not in VALID_API_HOSTS:
+            raise ValueError(
+                f"Refusing to authenticate to {host!r}: not in "
+                f"VALID_API_HOSTS {sorted(VALID_API_HOSTS)}"
+            )
+        return api_base_url
 
     def prepare_tokens(self) -> list[TokenManager]:  # type: ignore[override]
         env_dict = self.get_env()

--- a/tap_github_search/github_hosts.py
+++ b/tap_github_search/github_hosts.py
@@ -1,0 +1,60 @@
+"""Trusted GitHub API hosts for the search wrapper."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+DEFAULT_API_BASE_URL = "https://api.github.com"
+
+VALID_API_HOSTS = frozenset({
+    "api.github.com",
+    "github.a8c.com",
+    "github.tumblr.net",
+})
+
+INSTANCE_BY_API_HOST = {
+    "api.github.com": "github_com",
+    "github.a8c.com": "a8c_ghe",
+    "github.tumblr.net": "tumblr_ghe",
+}
+
+
+def normalize_api_base_url(api_url_base: str | None = None) -> str:
+    """Validate and normalize an API base URL before any request is built."""
+    raw_url = (api_url_base or DEFAULT_API_BASE_URL).strip().rstrip("/")
+    parsed = urlparse(raw_url)
+    host = (parsed.hostname or "").lower()
+
+    if parsed.scheme != "https":
+        raise ValueError(
+            f"api_url_base {raw_url!r} must use https "
+            f"(got scheme={parsed.scheme!r})"
+        )
+    if not host:
+        raise ValueError(f"api_url_base {raw_url!r} has no hostname")
+    if parsed.username or parsed.password:
+        raise ValueError(f"api_url_base {raw_url!r} must not include credentials")
+    if parsed.port not in (None, 443):
+        raise ValueError(f"api_url_base {raw_url!r} must not include a non-443 port")
+    if host not in VALID_API_HOSTS:
+        raise ValueError(
+            f"api_url_base host {host!r} not in allowlist "
+            f"{sorted(VALID_API_HOSTS)}; add the host if new"
+        )
+    if parsed.query or parsed.fragment or parsed.params:
+        raise ValueError(f"api_url_base {raw_url!r} must not include query or fragment")
+
+    return f"https://{host}{parsed.path.rstrip('/')}"
+
+
+def instance_from_api_base(api_url_base: str | None = None) -> str:
+    """Return the reporting instance for a trusted GitHub API base URL."""
+    if api_url_base == "":
+        return "unknown"
+    try:
+        normalized = normalize_api_base_url(api_url_base)
+    except ValueError:
+        return "unknown"
+    host = (urlparse(normalized).hostname or "").lower()
+    return INSTANCE_BY_API_HOST.get(host, "unknown")

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -11,7 +11,10 @@ import requests
 import json
 from collections import Counter
 
+import time
+
 from singer_sdk import typing as th
+from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.helpers.types import Context
 
 from tap_github.client import GitHubGraphqlStream
@@ -510,7 +513,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
     GRAPHQL_PR_VELOCITY: ClassVar[str] = """
     query PrVelocity($q: String!, $after: String) {
-      search(query: $q, type: ISSUE, first: 100, after: $after) {
+      search(query: $q, type: ISSUE, first: 50, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           ... on PullRequest {
@@ -592,12 +595,32 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         cfg_source = getattr(self, "_search_cfg", None) or self.config
         return cfg_source.get("search", {}).get("scope", {})
 
+    def _robust_graphql(self, query: str, variables: dict, api_url_base: str, tries: int = 8):
+        """Outer retry around _make_graphql_request: survives transient 502/gateway
+        timeouts on heavy queries (the inner request_decorator retries 5xx a few times;
+        this adds patient outer attempts with exponential backoff). Only transient
+        transport/5xx errors are retried; 4xx/auth/query errors fail fast."""
+        delay = 2.0
+        last_exc = None
+        for attempt in range(tries):
+            try:
+                return self._make_graphql_request(query, variables, api_url_base)
+            except (RetriableAPIError, requests.exceptions.RequestException) as exc:
+                last_exc = exc
+                self.logger.warning(
+                    "GraphQL request failed (attempt %d/%d): %s; backing off %.1fs",
+                    attempt + 1, tries, str(exc)[:140], delay,
+                )
+                time.sleep(delay)
+                delay = min(delay * 1.8, 60.0)
+        raise last_exc
+
     def _iter_pr_nodes(self, query: str, api_url_base: str):
         after = None
         skipped = 0
         seen_any = False
         while True:
-            resp = self._make_graphql_request(self.GRAPHQL_PR_VELOCITY, {"q": query, "after": after}, api_url_base)
+            resp = self._robust_graphql(self.GRAPHQL_PR_VELOCITY, {"q": query, "after": after}, api_url_base)
             search = resp.json()["data"]["search"]
             for node in search["nodes"]:
                 if not node or node.get("number") is None or not node.get("repository"):
@@ -615,7 +638,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         ids: set = set()
         after = None
         while True:
-            resp = self._make_graphql_request(self.GRAPHQL_PR_IDS, {"q": query, "after": after}, api_url_base)
+            resp = self._robust_graphql(self.GRAPHQL_PR_IDS, {"q": query, "after": after}, api_url_base)
             search = resp.json()["data"]["search"]
             for node in search["nodes"]:
                 if node and node.get("number") is not None and node.get("repository"):

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -6,6 +6,7 @@ import calendar
 import re
 from datetime import date, datetime, timedelta
 from typing import Any, ClassVar, Iterable, Mapping
+from urllib.parse import urlparse
 import os
 import requests
 import json
@@ -668,7 +669,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             th.Property("comment_count", th.IntegerType),
             th.Property("review_count", th.IntegerType),
             th.Property("commit_count", th.IntegerType),
-            th.Property("label_names", th.ArrayType(th.StringType)),
+            th.Property("label_names", th.StringType),
             th.Property("is_ai_authored", th.BooleanType),
             th.Property("is_ai_reviewed", th.BooleanType),
             th.Property("month", th.StringType),
@@ -812,7 +813,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             "comment_count": (node.get("comments") or {}).get("totalCount"),
             "review_count": (node.get("reviews") or {}).get("totalCount"),
             "commit_count": (node.get("commits") or {}).get("totalCount"),
-            "label_names": labels,
+            "label_names": json.dumps(labels),
             "is_ai_authored": False,
             "is_ai_reviewed": False,
             "month": month,
@@ -902,6 +903,35 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
 VALID_STREAM_MODES = frozenset({None, "pr_velocity"})
 
+# Hosts the tap is permitted to talk to. Defense-in-depth against a misconfigured
+# scope pointing the GraphQL/REST clients at an unintended endpoint (SSRF). The
+# operator config provides api_url_base; this list is the trusted set.
+VALID_API_HOSTS = frozenset({
+    "api.github.com",       # github.com public
+    "github.a8c.com",       # Automattic GHES
+    "github.tumblr.net",    # Tumblr GHES
+})
+
+
+def validate_scope(scope: dict) -> list[str]:
+    """Validate top-level scope settings (one check per scope, not per stream)."""
+    errors = []
+    api_url_base = scope.get("api_url_base")
+    if api_url_base:
+        parsed = urlparse(api_url_base)
+        if parsed.scheme != "https":
+            errors.append(
+                f"api_url_base {api_url_base!r} must use https (got scheme={parsed.scheme!r})"
+            )
+        elif not parsed.hostname:
+            errors.append(f"api_url_base {api_url_base!r} has no hostname")
+        elif parsed.hostname not in VALID_API_HOSTS:
+            errors.append(
+                f"api_url_base host {parsed.hostname!r} not in allowlist "
+                f"{sorted(VALID_API_HOSTS)}; add the host to VALID_API_HOSTS if new"
+            )
+    return errors
+
 
 def validate_stream_config(stream_config: dict) -> list[str]:
     errors = []
@@ -945,6 +975,11 @@ def create_configurable_streams(tap, config_override: dict | None = None) -> lis
     
     if "search" in config:
         s = config.get("search", {})
+        scope_errors = validate_scope(s.get("scope", {}))
+        if scope_errors:
+            for err in scope_errors:
+                tap.logger.error(f"Invalid scope: {err}")
+            raise ValueError(f"Invalid scope: {'; '.join(scope_errors)}")
         for sd in s.get("streams", []):
             sc = {
                 "name": sd.get("name"),

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -14,8 +14,24 @@ from collections import Counter
 import time
 
 from singer_sdk import typing as th
-from singer_sdk.exceptions import RetriableAPIError
+from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 from singer_sdk.helpers.types import Context
+
+
+def _is_transient_graphql_failure(exc: Exception) -> bool:
+    """True for transient server-side failures worth retrying/skipping.
+    Covers 502/5xx (RetriableAPIError), transport errors (RequestException), AND
+    GitHub's HTTP-200 GraphQL 'INTERNAL' / 'Something went wrong' errors, which
+    tap-github maps to FatalAPIError but are in fact transient (heavy-query glitches).
+    Genuine 4xx/auth/validation FatalAPIErrors return False (fail fast)."""
+    if isinstance(exc, (RetriableAPIError, requests.exceptions.RequestException)):
+        return True
+    if isinstance(exc, FatalAPIError):
+        m = str(exc).lower()
+        return "graphql error" in m and (
+            "internal" in m or "something went wrong" in m or "timeout" in m or "timed out" in m
+        )
+    return False
 
 from tap_github.client import GitHubGraphqlStream
 from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
@@ -513,7 +529,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
     GRAPHQL_PR_VELOCITY: ClassVar[str] = """
     query PrVelocity($q: String!, $after: String) {
-      search(query: $q, type: ISSUE, first: 50, after: $after) {
+      search(query: $q, type: ISSUE, first: 25, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           ... on PullRequest {
@@ -538,7 +554,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
     GRAPHQL_PR_IDS: ClassVar[str] = """
     query PrIds($q: String!, $after: String) {
-      search(query: $q, type: ISSUE, first: 100, after: $after) {
+      search(query: $q, type: ISSUE, first: 50, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes { ... on PullRequest { number repository { nameWithOwner } } }
       }
@@ -605,7 +621,9 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         for attempt in range(tries):
             try:
                 return self._make_graphql_request(query, variables, api_url_base)
-            except (RetriableAPIError, requests.exceptions.RequestException) as exc:
+            except Exception as exc:
+                if not _is_transient_graphql_failure(exc):
+                    raise  # genuine 4xx/auth/validation/parse error -- fail fast
                 last_exc = exc
                 self.logger.warning(
                     "GraphQL request failed (attempt %d/%d): %s; backing off %.1fs",
@@ -713,8 +731,25 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             row["is_ai_reviewed"] = key in ai_reviewed_ids
             yield row
 
+    def _emit_window(self, window_query, api_url_base, instance, org, month, now, markers, reviewer):
+        """Materialize one window's rows atomically. If the window's queries keep failing
+        even after _robust_graphql exhausts its retries (a persistently-too-expensive page
+        that keeps 502-ing), log and SKIP that window instead of crashing the whole org's
+        sync. Skipped windows are counted and reported so gaps are known and re-fetchable."""
+        try:
+            return list(self._process_window(window_query, api_url_base, instance, org, month, now, markers, reviewer))
+        except Exception as exc:
+            if not _is_transient_graphql_failure(exc):
+                raise  # don't mask genuine bugs (parse errors, auth) -- only skip transient failures
+            self._skipped_windows += 1
+            self.logger.error(
+                "SKIPPING window after exhausted retries (%s): %s", window_query, str(exc)[:140]
+            )
+            return []
+
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
         now = datetime.utcnow().isoformat() + "Z"
+        self._skipped_windows = 0
         partitions_to_process = [context] if context else self.partitions
         markers = self.stream_config.get("markers", []) or []
         reviewer = self.stream_config.get("reviewer_clause", "") or ""
@@ -731,11 +766,16 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             if month_count == 0:
                 continue
             if month_count <= NODES_THRESHOLD:
-                yield from self._process_window(query, api_url_base, instance, org, month, now, markers, reviewer)
+                yield from self._emit_window(query, api_url_base, instance, org, month, now, markers, reviewer)
             else:
                 self.logger.info("Month %s for %s has %d > %d results; day-slicing.", month, org, month_count, NODES_THRESHOLD)
                 for day_query in self._iter_day_queries(query):
-                    yield from self._process_window(day_query, api_url_base, instance, org, month, now, markers, reviewer)
+                    yield from self._emit_window(day_query, api_url_base, instance, org, month, now, markers, reviewer)
+        if self._skipped_windows:
+            self.logger.warning(
+                "pr_velocity for %s: %d window(s) SKIPPED after exhausted retries -- data has known gaps.",
+                org, self._skipped_windows,
+            )
 
 
 def validate_stream_config(stream_config: dict) -> list[str]:

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -70,10 +70,14 @@ def _is_transient_graphql_failure(exc: Exception) -> bool:
             except Exception:
                 payload = None
             if isinstance(payload, dict):
-                for err in (payload.get("errors") or []):
-                    err_type = (err.get("type") or "").upper()
-                    if err_type in TRANSIENT_GRAPHQL_ERROR_TYPES:
-                        return True
+                errors_list = payload.get("errors")
+                if isinstance(errors_list, list):
+                    for err in errors_list:
+                        if not isinstance(err, dict):
+                            continue  # defensive: malformed error entries
+                        err_type = (err.get("type") or "").upper()
+                        if err_type in TRANSIENT_GRAPHQL_ERROR_TYPES:
+                            return True
         # Fallback substring match for environments where response parsing fails
         # (kept narrow to avoid false positives on real 4xx error messages).
         m = str(exc).lower()
@@ -692,6 +696,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             tries = int(os.environ.get("TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES", "5"))
         if max_wall_seconds is None:
             max_wall_seconds = float(os.environ.get("TAP_GITHUB_SEARCH_VELOCITY_MAX_WALL_SECONDS", "180"))
+        if tries < 1:
+            raise ValueError(f"_robust_graphql: tries must be >= 1, got {tries}")
         start = time.monotonic()
         delay = 2.0
         last_exc = None

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -18,19 +18,74 @@ from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 from singer_sdk.helpers.types import Context
 
 
+# GraphQL error `type` values that indicate a transient server-side failure (worth
+# retrying or skipping the window). Source: GitHub GraphQL API error responses on
+# overloaded queries / brief gateway issues. Permanent errors (FORBIDDEN, NOT_FOUND,
+# UNAUTHORIZED, etc.) are NOT in this set and will fail fast.
+TRANSIENT_GRAPHQL_ERROR_TYPES = frozenset({
+    "INTERNAL",
+    "RATE_LIMITED",
+    "SERVICE_UNAVAILABLE",
+    "MAX_NODE_LIMIT_EXCEEDED",
+    "TIMEOUT",
+    "BAD_GATEWAY",
+})
+
+
 def _is_transient_graphql_failure(exc: Exception) -> bool:
     """True for transient server-side failures worth retrying/skipping.
-    Covers 502/5xx (RetriableAPIError), transport errors (RequestException), AND
-    GitHub's HTTP-200 GraphQL 'INTERNAL' / 'Something went wrong' errors, which
-    tap-github maps to FatalAPIError but are in fact transient (heavy-query glitches).
-    Genuine 4xx/auth/validation FatalAPIErrors return False (fail fast)."""
+
+    Covers:
+      - 502/5xx and transport errors (RetriableAPIError, requests.RequestException).
+      - GitHub's HTTP-200 GraphQL responses with a transient `errors[*].type`
+        (INTERNAL, RATE_LIMITED, SERVICE_UNAVAILABLE, etc.) which tap-github maps to
+        FatalAPIError but are in fact transient.
+      - HTTP 403 secondary-rate-limit responses, identified by body text containing
+        "secondary rate limit" or "abuse" (current code mistakenly treats these as
+        permanent FORBIDDEN).
+
+    Permanent failures (genuine 4xx auth/validation, FORBIDDEN org-policy blocks,
+    NOT_FOUND, etc.) return False and fail fast.
+    """
     if isinstance(exc, (RetriableAPIError, requests.exceptions.RequestException)):
         return True
     if isinstance(exc, FatalAPIError):
+        # Structural parsing of the response body (preferred over substring matching).
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            # 403 with secondary-rate-limit signature: transient (the regular
+            # FORBIDDEN classic-PAT block is permanent and does NOT match this).
+            status = getattr(resp, "status_code", None)
+            if status == 403:
+                try:
+                    body = (resp.text or "").lower()
+                except Exception:
+                    body = ""
+                if "secondary rate limit" in body or "abuse detection" in body:
+                    return True
+            # 200 with structured GraphQL `errors[*].type`: transient if any error's
+            # type is in our transient set.
+            try:
+                payload = resp.json()
+            except Exception:
+                payload = None
+            if isinstance(payload, dict):
+                for err in (payload.get("errors") or []):
+                    err_type = (err.get("type") or "").upper()
+                    if err_type in TRANSIENT_GRAPHQL_ERROR_TYPES:
+                        return True
+        # Fallback substring match for environments where response parsing fails
+        # (kept narrow to avoid false positives on real 4xx error messages).
         m = str(exc).lower()
-        return "graphql error" in m and (
-            "internal" in m or "something went wrong" in m or "timeout" in m or "timed out" in m
-        )
+        if "graphql error" in m and any(
+            tok in m for tok in (
+                "'type': 'internal'",
+                "'type': 'rate_limited'",
+                "'type': 'service_unavailable'",
+                "something went wrong while executing",
+            )
+        ):
+            return True
     return False
 
 from tap_github.client import GitHubGraphqlStream
@@ -562,6 +617,12 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
     }
     """
 
+    # Day-window pre-flight threshold: if a day's issueCount is at or above this,
+    # we know GraphQL search will silently truncate at 1000. Skip + log loudly with
+    # 100-PR safety margin. Empirical day-max on busy orgs is ~400; this only
+    # protects against future spike days.
+    DAY_PREFLIGHT_CAP: ClassVar[int] = 900
+
     def __init__(self, stream_config: dict, tap):
         self.stream_config = stream_config
         self.query_template = stream_config["query_template"]
@@ -569,6 +630,9 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         self.name = stream_config["name"]
         self.stream_type = stream_config.get("stream_type", stream_config.get("name", "pr_velocity"))
         self.tap = tap
+        # Cumulative across all partitions for this stream's lifetime; get_records tracks
+        # per-partition deltas for attributed logging.
+        self._skipped_windows = 0
         # Skip ConfigurableSearchCountStream.__init__ (it forces the *_search_counts name + count schema).
         SearchCountStreamBase.__init__(self, tap=tap, name=self.name, schema=self.get_schema())
 
@@ -611,11 +675,24 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         cfg_source = getattr(self, "_search_cfg", None) or self.config
         return cfg_source.get("search", {}).get("scope", {})
 
-    def _robust_graphql(self, query: str, variables: dict, api_url_base: str, tries: int = 8):
+    def _robust_graphql(self, query: str, variables: dict, api_url_base: str, tries: int | None = None, max_wall_seconds: float | None = None):
         """Outer retry around _make_graphql_request: survives transient 502/gateway
         timeouts on heavy queries (the inner request_decorator retries 5xx a few times;
-        this adds patient outer attempts with exponential backoff). Only transient
-        transport/5xx errors are retried; 4xx/auth/query errors fail fast."""
+        this adds patient outer attempts with exponential backoff).
+
+        Only transient transport/5xx/GraphQL-INTERNAL errors are retried; 4xx/auth
+        errors fail fast.
+
+        Bounded by both attempt count AND wall-time so a sustained outage can't block
+        a partition for hours. Both are env-configurable for ops tuning:
+          TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES (default 5)
+          TAP_GITHUB_SEARCH_VELOCITY_MAX_WALL_SECONDS (default 180)
+        """
+        if tries is None:
+            tries = int(os.environ.get("TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES", "5"))
+        if max_wall_seconds is None:
+            max_wall_seconds = float(os.environ.get("TAP_GITHUB_SEARCH_VELOCITY_MAX_WALL_SECONDS", "180"))
+        start = time.monotonic()
         delay = 2.0
         last_exc = None
         for attempt in range(tries):
@@ -625,9 +702,16 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 if not _is_transient_graphql_failure(exc):
                     raise  # genuine 4xx/auth/validation/parse error -- fail fast
                 last_exc = exc
+                elapsed = time.monotonic() - start
+                if elapsed >= max_wall_seconds:
+                    self.logger.warning(
+                        "GraphQL request exceeded wall-time budget %.0fs after %d attempt(s); giving up.",
+                        max_wall_seconds, attempt + 1,
+                    )
+                    raise
                 self.logger.warning(
-                    "GraphQL request failed (attempt %d/%d): %s; backing off %.1fs",
-                    attempt + 1, tries, str(exc)[:140], delay,
+                    "GraphQL request failed (attempt %d/%d, %.1fs elapsed): %s; backing off %.1fs",
+                    attempt + 1, tries, elapsed, str(exc)[:140], delay,
                 )
                 time.sleep(delay)
                 delay = min(delay * 1.8, 60.0)
@@ -650,7 +734,17 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 break
             after = search["pageInfo"]["endCursor"]
         if skipped and not seen_any:
-            raise RuntimeError(f"All {skipped} node(s) skipped for query: {query} -- token may lack repo access")
+            # All nodes were null/inaccessible across all pages. This usually means
+            # the token lacks access to every repo in this window, OR every result
+            # was a ghost-user PR. Don't raise -- crashing the whole org's sync over
+            # one bad window is worse than emitting zero rows for that window. Log
+            # loudly so ops can investigate.
+            self.logger.error(
+                "All %d node(s) returned null/inaccessible for query: %s -- "
+                "likely a token-access issue; emitting 0 rows for this window.",
+                skipped, query,
+            )
+            return
 
     def _collect_pr_ids(self, query: str, api_url_base: str) -> set:
         ids: set = set()
@@ -749,11 +843,11 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
         now = datetime.utcnow().isoformat() + "Z"
-        self._skipped_windows = 0
         partitions_to_process = [context] if context else self.partitions
         markers = self.stream_config.get("markers", []) or []
         reviewer = self.stream_config.get("reviewer_clause", "") or ""
         for partition in partitions_to_process:
+            partition_skipped_start = self._skipped_windows  # delta-track per partition
             org = partition["org"]
             month = partition["month"]
             query = partition["search_query"]
@@ -770,12 +864,37 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             else:
                 self.logger.info("Month %s for %s has %d > %d results; day-slicing.", month, org, month_count, NODES_THRESHOLD)
                 for day_query in self._iter_day_queries(query):
+                    # Peak-day pre-flight: if a single day would hit/exceed the 1000-
+                    # result search cap, pagination silently truncates. Detect via a
+                    # cheap issueCount probe and skip+log loudly rather than emit a
+                    # partial day. Repo-split fallback is a documented next step.
+                    try:
+                        day_count = self._search_aggregate_count(day_query, api_url_base)
+                    except Exception as exc:
+                        # Don't crash the org over a probe failure; treat as 0 and let
+                        # _emit_window's retry/skip handle the subsequent fetch.
+                        self.logger.warning("Day-count probe failed for %s: %s", day_query, str(exc)[:140])
+                        day_count = 0
+                    if day_count >= self.DAY_PREFLIGHT_CAP:
+                        self._skipped_windows += 1
+                        self.logger.error(
+                            "SKIPPING day-window: count=%d >= cap=%d (search would silently truncate). "
+                            "Sub-slice by repo or refine the query. Window: %s",
+                            day_count, self.DAY_PREFLIGHT_CAP, day_query,
+                        )
+                        continue
                     yield from self._emit_window(day_query, api_url_base, instance, org, month, now, markers, reviewer)
-        if self._skipped_windows:
-            self.logger.warning(
-                "pr_velocity for %s: %d window(s) SKIPPED after exhausted retries -- data has known gaps.",
-                org, self._skipped_windows,
-            )
+            # Per-partition skip attribution -- attributes correctly to (instance, org, month)
+            # rather than reporting the last-iterated org with the aggregate count.
+            partition_skipped = self._skipped_windows - partition_skipped_start
+            if partition_skipped:
+                self.logger.warning(
+                    "pr_velocity: %d window(s) SKIPPED for instance=%s org=%s month=%s -- data has known gaps.",
+                    partition_skipped, instance, org, month,
+                )
+
+
+VALID_STREAM_MODES = frozenset({None, "pr_velocity"})
 
 
 def validate_stream_config(stream_config: dict) -> list[str]:
@@ -791,6 +910,12 @@ def validate_stream_config(stream_config: dict) -> list[str]:
     for placeholder in ["{org}", "{start}", "{end}"]:
         if placeholder not in query_template:
             errors.append(f"Query template must contain {placeholder} placeholder")
+    mode = stream_config.get("mode")
+    if mode not in VALID_STREAM_MODES:
+        errors.append(
+            f"Unknown mode {mode!r}: expected one of {sorted(repr(m) for m in VALID_STREAM_MODES)} "
+            f"(omit `mode` for the default count stream)"
+        )
     return errors
 
 

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -2,21 +2,35 @@
 
 from __future__ import annotations
 
+import base64
 import calendar
-import re
-from datetime import date, datetime, timedelta
-from typing import Any, ClassVar, Iterable, Mapping
-from urllib.parse import urlparse
-import os
-import requests
 import json
-from collections import Counter
-
+import os
+import re
 import time
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, ClassVar, Iterable
+
+import requests
 
 from singer_sdk import typing as th
 from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 from singer_sdk.helpers.types import Context
+
+from tap_github.client import GitHubGraphqlStream
+from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
+from tap_github_search.github_hosts import (
+    VALID_API_HOSTS as VALID_API_HOSTS,
+    instance_from_api_base,
+    normalize_api_base_url,
+)
+from tap_github_search.utils.date_utils import (
+    get_last_complete_month,
+    get_last_complete_month_date,
+    month_range,
+    month_to_date,
+)
 
 
 # GraphQL error `type` values that indicate a transient server-side failure (worth
@@ -31,6 +45,70 @@ TRANSIENT_GRAPHQL_ERROR_TYPES = frozenset({
     "TIMEOUT",
     "BAD_GATEWAY",
 })
+
+RATE_LIMIT_GRAPHQL_ERROR_TYPES = frozenset({"RATE_LIMITED"})
+
+
+def _response_for_exception(exc: Exception):
+    return getattr(exc, "response", None)
+
+
+def _graphql_error_types_from_response(response) -> set[str]:
+    try:
+        payload = response.json()
+    except Exception:
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    errors_list = payload.get("errors")
+    if not isinstance(errors_list, list):
+        return set()
+    return {
+        str(err.get("type", "")).upper()
+        for err in errors_list
+        if isinstance(err, dict) and err.get("type")
+    }
+
+
+def _is_rate_limit_failure(exc: Exception) -> bool:
+    resp = _response_for_exception(exc)
+    if resp is not None:
+        if _graphql_error_types_from_response(resp) & RATE_LIMIT_GRAPHQL_ERROR_TYPES:
+            return True
+        status = getattr(resp, "status_code", None)
+        if status in (403, 429):
+            try:
+                body = (resp.text or "").lower()
+            except Exception:
+                body = ""
+            return "rate limit" in body or "abuse detection" in body
+
+    message = str(exc).lower()
+    return "rate_limited" in message or "rate limit" in message
+
+
+def _retry_delay_seconds(exc: Exception, fallback: float) -> float:
+    resp = _response_for_exception(exc)
+    headers = getattr(resp, "headers", {}) if resp is not None else {}
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    if retry_after:
+        try:
+            return max(float(retry_after), 0.0)
+        except ValueError:
+            pass
+
+    reset_at = headers.get("X-RateLimit-Reset") or headers.get("x-ratelimit-reset")
+    if reset_at:
+        try:
+            return max(float(reset_at) - time.time(), 0.0)
+        except ValueError:
+            pass
+
+    return fallback
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _is_transient_graphql_failure(exc: Exception) -> bool:
@@ -52,7 +130,7 @@ def _is_transient_graphql_failure(exc: Exception) -> bool:
         return True
     if isinstance(exc, FatalAPIError):
         # Structural parsing of the response body (preferred over substring matching).
-        resp = getattr(exc, "response", None)
+        resp = _response_for_exception(exc)
         if resp is not None:
             # 403 with secondary-rate-limit signature: transient (the regular
             # FORBIDDEN classic-PAT block is permanent and does NOT match this).
@@ -66,19 +144,8 @@ def _is_transient_graphql_failure(exc: Exception) -> bool:
                     return True
             # 200 with structured GraphQL `errors[*].type`: transient if any error's
             # type is in our transient set.
-            try:
-                payload = resp.json()
-            except Exception:
-                payload = None
-            if isinstance(payload, dict):
-                errors_list = payload.get("errors")
-                if isinstance(errors_list, list):
-                    for err in errors_list:
-                        if not isinstance(err, dict):
-                            continue  # defensive: malformed error entries
-                        err_type = (err.get("type") or "").upper()
-                        if err_type in TRANSIENT_GRAPHQL_ERROR_TYPES:
-                            return True
+            if _graphql_error_types_from_response(resp) & TRANSIENT_GRAPHQL_ERROR_TYPES:
+                return True
         # Fallback substring match for environments where response parsing fails
         # (kept narrow to avoid false positives on real 4xx error messages).
         m = str(exc).lower()
@@ -93,24 +160,14 @@ def _is_transient_graphql_failure(exc: Exception) -> bool:
             return True
     return False
 
-from tap_github.client import GitHubGraphqlStream
-from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
-
 # Essential batching configuration
 BATCH_SIZE = int(os.environ.get("TAP_GITHUB_SEARCH_BATCH_SIZE", "100"))
 NODES_THRESHOLD = 1000  # Threshold for using nodes approach vs batching
 
 # Regex patterns for query parsing
 ORG_PATTERN = re.compile(r"\borg:([^\s]+)")
-REPO_PATTERN = re.compile(r"\brepo:([^\s/]+)/([^\s]+)")  
+REPO_PATTERN = re.compile(r"\brepo:([^\s/]+)/([^\s]+)")
 ORG_REPLACEMENT_PATTERN = re.compile(r"\borg:[^\s]+\s*")
-
-from tap_github_search.utils.date_utils import (
-    get_last_complete_month,
-    get_last_complete_month_date,
-    month_to_date,
-    month_range,
-)
 
 
 class SearchCountStreamBase(GitHubGraphqlStream):
@@ -146,7 +203,7 @@ class SearchCountStreamBase(GitHubGraphqlStream):
     def _make_graphql_request(self, query_template: str, variables: dict[str, Any], api_url_base: str):
         """Make a GraphQL request with standardized payload building."""
         payload = self._build_graphql_payload(query_template, variables)
-        graphql_base = api_url_base.rstrip("/").removesuffix("/v3")
+        graphql_base = normalize_api_base_url(api_url_base).removesuffix("/v3")
         prepared_request = self.build_prepared_request(method="POST", url=f"{graphql_base}/graphql", json=payload)
         decorated_request = self.request_decorator(self._request)
         return decorated_request(prepared_request, None)
@@ -240,8 +297,79 @@ class SearchCountStreamBase(GitHubGraphqlStream):
             return True
         return month_date > bookmark_date
 
+    def _build_search_query(self, org: str, start_date: str, end_date: str, stream_type: str) -> str:
+        return self.query_template.format(org=org, start=start_date, end=end_date)
+
+    def _build_repo_search_query(self, repo: str, start_date: str, end_date: str, stream_type: str) -> str:
+        return self.query_template.format(org=repo, start=start_date, end=end_date)
+
+    @property
+    def partitions(self) -> list[Context]:
+        cfg_source = getattr(self, "_search_cfg", None) or self.config
+        s = cfg_source.get("search", {})
+        scope = s.get("scope", {})
+        orgs = scope.get("orgs", [])
+        repos = scope.get("repos", [])
+        api_url_base = normalize_api_base_url(scope.get("api_url_base"))
+        breakdown = scope.get("breakdown", "none") == "repo"
+        if not orgs and not repos:
+            self.logger.warning(f"No orgs or repos provided for {self.name}")
+            return []
+
+        partitions: list[Context] = []
+        months = self._get_months_to_process()
+        stream_name = self.stream_config["name"]
+
+        org_bookmarks: dict[tuple[str, str], date | None] = {}
+        for org in orgs:
+            bookmark_str = self._get_bookmark_for_context({"org": org})
+            org_bookmarks[("single", org)] = month_to_date(bookmark_str) if bookmark_str else None
+
+        repo_bookmarks: dict[tuple[str, str], date | None] = {}
+        for repo in repos:
+            bookmark_str = self._get_bookmark_for_context({"org": repo, "repo": repo})
+            repo_bookmarks[("single", repo)] = month_to_date(bookmark_str) if bookmark_str else None
+
+        for month in months:
+            year, month_num = map(int, month.split("-"))
+            start_date = f"{year:04d}-{month_num:02d}-01"
+            last_day = calendar.monthrange(year, month_num)[1]
+            end_date = f"{year:04d}-{month_num:02d}-{last_day:02d}"
+
+            for org in orgs:
+                bookmark_date = org_bookmarks.get(("single", org))
+                if self._should_include_month(month, bookmark_date):
+                    query = self._build_search_query(org, start_date, end_date, self.stream_type)
+                    partitions.append({
+                        "search_name": stream_name,
+                        "search_query": query,
+                        "api_url_base": api_url_base,
+                        "org": org,
+                        "month": month,
+                        "kind": stream_name,
+                        "repo_breakdown": breakdown,
+                    })
+
+            for repo in repos:
+                org = repo.split("/")[0]
+                bookmark_date = repo_bookmarks.get(("single", repo))
+                if self._should_include_month(month, bookmark_date):
+                    query = self._build_repo_search_query(repo, start_date, end_date, self.stream_type)
+                    partitions.append({
+                        "search_name": stream_name,
+                        "search_query": query,
+                        "api_url_base": api_url_base,
+                        "org": org,
+                        "month": month,
+                        "kind": stream_name,
+                        "repo_breakdown": False,
+                    })
+
+        self.logger.info(f"Generated {len(partitions)} partitions after incremental filtering")
+        return partitions
+
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
-        now = datetime.utcnow().isoformat() + "Z"
+        now = _utc_now_z()
         partitions_to_process = [context] if context else self.partitions
         
         for partition in partitions_to_process:
@@ -478,87 +606,9 @@ class ConfigurableSearchCountStream(SearchCountStreamBase):
         self.tap = tap
         super().__init__(tap=tap, name=self.name, schema=self.get_schema())
 
-    def _build_search_query(self, org: str, start_date: str, end_date: str, stream_type: str) -> str:
-        return self.query_template.format(org=org, start=start_date, end=end_date)
-
-    def _build_repo_search_query(self, repo: str, start_date: str, end_date: str, stream_type: str) -> str:
-        return self.query_template.format(org=repo, start=start_date, end=end_date)
-
-    @property
-    def partitions(self) -> list[Context]:
-        cfg_source = getattr(self, "_search_cfg", None) or self.config
-        s = cfg_source.get("search", {})
-        scope = s.get("scope", {})
-        orgs = scope.get("orgs", [])
-        repos = scope.get("repos", [])
-        api_url_base = scope.get("api_url_base", "https://api.github.com")
-        breakdown = scope.get("breakdown", "none") == "repo"
-        if not orgs and not repos:
-            self.logger.warning(f"No orgs or repos provided for {self.name}")
-            return []
-
-        partitions: list[Context] = []
-        months = self._get_months_to_process()
-        stream_name = self.stream_config["name"]
-
-        org_bookmarks: dict[tuple[str, str], date | None] = {}
-        for org in orgs:
-            bookmark_str = self._get_bookmark_for_context({"org": org})
-            org_bookmarks[("single", org)] = month_to_date(bookmark_str) if bookmark_str else None
-
-        repo_bookmarks: dict[tuple[str, str], date | None] = {}
-        for repo in repos:
-            bookmark_str = self._get_bookmark_for_context({"org": repo, "repo": repo})
-            repo_bookmarks[("single", repo)] = month_to_date(bookmark_str) if bookmark_str else None
-
-        for month in months:
-            year, month_num = map(int, month.split("-"))
-            start_date = f"{year:04d}-{month_num:02d}-01"
-            last_day = calendar.monthrange(year, month_num)[1]
-            end_date = f"{year:04d}-{month_num:02d}-{last_day:02d}"
-
-            for org in orgs:
-                bookmark_date = org_bookmarks.get(("single", org))
-                if self._should_include_month(month, bookmark_date):
-                    query = self._build_search_query(org, start_date, end_date, self.stream_type)
-                    partitions.append({
-                        "search_name": stream_name,
-                        "search_query": query,
-                        "api_url_base": api_url_base,
-                        "org": org,
-                        "month": month,
-                        "kind": stream_name,
-                        "repo_breakdown": breakdown,
-                    })
-
-            for repo in repos:
-                org = repo.split("/")[0]
-                bookmark_date = repo_bookmarks.get(("single", repo))
-                if self._should_include_month(month, bookmark_date):
-                    query = self._build_repo_search_query(repo, start_date, end_date, self.stream_type)
-                    partitions.append({
-                        "search_name": stream_name,
-                        "search_query": query,
-                        "api_url_base": api_url_base,
-                        "org": org,
-                        "month": month,
-                        "kind": stream_name,
-                        "repo_breakdown": False,
-                    })
-
-        self.logger.info(f"Generated {len(partitions)} partitions after incremental filtering")
-        return partitions
-
 
 def _instance_from_api_base(api_url_base: str) -> str:
-    base = (api_url_base or "").lower()
-    if "github.a8c.com" in base:
-        return "a8c_ghe"
-    if "github.tumblr.net" in base:
-        return "tumblr_ghe"
-    if "api.github.com" in base or "github.com" in base:
-        return "github_com"
-    return "unknown"
+    return instance_from_api_base(api_url_base)
 
 
 CLOSED_RANGE_RE = re.compile(r"closed:\d{4}-\d{2}-\d{2}\.\.\d{4}-\d{2}-\d{2}")
@@ -573,19 +623,33 @@ def _hours_between(created: str | None, closed: str | None) -> float | None:
     return round((c1 - c0).total_seconds() / 3600.0, 4)
 
 
-class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
+def _marker_to_literal(marker: str) -> str:
+    marker = marker.strip()
+    if len(marker) >= 2 and marker[0] == marker[-1] and marker[0] in {"'", '"'}:
+        return marker[1:-1]
+    return marker
+
+
+def _body_contains_marker(body_text: str | None, marker: str) -> bool:
+    literal = _marker_to_literal(marker)
+    if not literal:
+        return False
+    return literal.casefold() in (body_text or "").casefold()
+
+
+class ConfigurablePrVelocityStream(SearchCountStreamBase):
     """Per-PR velocity stream: one row per closed PR with timing + AI cohort flags.
 
-    Reuses the count stream's transport, auth, monthly partitioning and _search_cfg
-    injection; overrides the schema and get_records to emit per-PR rows. The base
-    is:closed query is day-sliced to stay under the 1000-result search cap, and AI
-    membership is folded into is_ai_authored / is_ai_reviewed booleans before emit.
+    Reuses the wrapper transport, auth, monthly partitioning and _search_cfg
+    injection, but emits per-PR rows. The base is:closed query is day-sliced to
+    stay under the 1000-result search cap, and AI membership is folded into
+    is_ai_authored / is_ai_reviewed booleans before emit.
     """
 
-    replication_method: ClassVar[str] = "FULL_TABLE"
-    replication_key = None
+    replication_method: ClassVar[str] = "INCREMENTAL"
+    replication_key = "month"
     primary_keys: ClassVar[list[str]] = ["instance", "org", "repo", "pr_number"]
-    state_partitioning_keys: ClassVar[list[str]] = []
+    state_partitioning_keys: ClassVar[list[str]] = ["org"]
 
     GRAPHQL_PR_VELOCITY: ClassVar[str] = """
     query PrVelocity($q: String!, $after: String) {
@@ -593,7 +657,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         pageInfo { hasNextPage endCursor }
         nodes {
           ... on PullRequest {
-            number title url state isDraft
+            number title bodyText url state isDraft
             createdAt closedAt mergedAt updatedAt
             author { login }
             mergedBy { login }
@@ -601,10 +665,10 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             baseRefName headRefName
             additions deletions changedFiles
             reviewDecision
-            comments { totalCount }
-            reviews { totalCount }
-            commits { totalCount }
-            labels(first: 10) { nodes { name } }
+            comments(first: 1) { totalCount }
+            reviews(first: 1) { totalCount }
+            commits(first: 1) { totalCount }
+            labels(first: 100) { nodes { name } }
           }
         }
       }
@@ -622,11 +686,9 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
     }
     """
 
-    # Day-window pre-flight threshold: if a day's issueCount is at or above this,
-    # we know GraphQL search will silently truncate at 1000. Skip + log loudly with
-    # 100-PR safety margin. Empirical day-max on busy orgs is ~400; this only
-    # protects against future spike days.
-    DAY_PREFLIGHT_CAP: ClassVar[int] = 900
+    # Day-window pre-flight threshold: GraphQL search only returns the first 1000
+    # results. Skip + log loudly only when a day is above that retrievable cap.
+    DAY_PREFLIGHT_CAP: ClassVar[int] = NODES_THRESHOLD
 
     def __init__(self, stream_config: dict, tap):
         self.stream_config = stream_config
@@ -638,7 +700,6 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         # Cumulative across all partitions for this stream's lifetime; get_records tracks
         # per-partition deltas for attributed logging.
         self._skipped_windows = 0
-        # Skip ConfigurableSearchCountStream.__init__ (it forces the *_search_counts name + count schema).
         SearchCountStreamBase.__init__(self, tap=tap, name=self.name, schema=self.get_schema())
 
     @classmethod
@@ -710,7 +771,10 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                     raise  # genuine 4xx/auth/validation/parse error -- fail fast
                 last_exc = exc
                 elapsed = time.monotonic() - start
-                if elapsed >= max_wall_seconds:
+                next_delay = _retry_delay_seconds(exc, delay) if _is_rate_limit_failure(exc) else delay
+                if attempt == tries - 1:
+                    raise
+                if elapsed + next_delay >= max_wall_seconds:
                     self.logger.warning(
                         "GraphQL request exceeded wall-time budget %.0fs after %d attempt(s); giving up.",
                         max_wall_seconds, attempt + 1,
@@ -718,9 +782,9 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                     raise
                 self.logger.warning(
                     "GraphQL request failed (attempt %d/%d, %.1fs elapsed): %s; backing off %.1fs",
-                    attempt + 1, tries, elapsed, str(exc)[:140], delay,
+                    attempt + 1, tries, elapsed, str(exc)[:140], next_delay,
                 )
-                time.sleep(delay)
+                time.sleep(next_delay)
                 delay = min(delay * 1.8, 60.0)
         raise last_exc
 
@@ -751,7 +815,13 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 "likely a token-access issue; emitting 0 rows for this window.",
                 skipped, query,
             )
+            self._skipped_windows += 1
             return
+        if skipped:
+            self.logger.warning(
+                "Skipped %d null/inaccessible node(s) in search results for query: %s",
+                skipped, query,
+            )
 
     def _collect_pr_ids(self, query: str, api_url_base: str) -> set:
         ids: set = set()
@@ -821,14 +891,14 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         }
 
     def _process_window(self, window_query, api_url_base, instance, org, month, now, markers, reviewer):
-        ai_authored_ids: set = set()
-        for marker in markers:
-            ai_authored_ids |= self._collect_pr_ids(f"{window_query} {marker}", api_url_base)
         ai_reviewed_ids = self._collect_pr_ids(f"{window_query} {reviewer}", api_url_base) if reviewer else set()
         for node in self._iter_pr_nodes(window_query, api_url_base):
             row = self._node_to_row(node, instance, org, month, now)
             key = f"{node['repository']['nameWithOwner']}#{node['number']}"
-            row["is_ai_authored"] = key in ai_authored_ids
+            row["is_ai_authored"] = any(
+                _body_contains_marker(node.get("bodyText"), marker)
+                for marker in markers
+            )
             row["is_ai_reviewed"] = key in ai_reviewed_ids
             yield row
 
@@ -842,6 +912,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         except Exception as exc:
             if not _is_transient_graphql_failure(exc):
                 raise  # don't mask genuine bugs (parse errors, auth) -- only skip transient failures
+            if _is_rate_limit_failure(exc):
+                raise  # rate limits should pause/fail the sync, not become data gaps
             self._skipped_windows += 1
             self.logger.error(
                 "SKIPPING window after exhausted retries (%s): %s", window_query, str(exc)[:140]
@@ -849,7 +921,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             return []
 
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
-        now = datetime.utcnow().isoformat() + "Z"
+        now = _utc_now_z()
         partitions_to_process = [context] if context else self.partitions
         markers = self.stream_config.get("markers", []) or []
         reviewer = self.stream_config.get("reviewer_clause", "") or ""
@@ -871,21 +943,14 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             else:
                 self.logger.info("Month %s for %s has %d > %d results; day-slicing.", month, org, month_count, NODES_THRESHOLD)
                 for day_query in self._iter_day_queries(query):
-                    # Peak-day pre-flight: if a single day would hit/exceed the 1000-
-                    # result search cap, pagination silently truncates. Detect via a
-                    # cheap issueCount probe and skip+log loudly rather than emit a
-                    # partial day. Repo-split fallback is a documented next step.
-                    try:
-                        day_count = self._search_aggregate_count(day_query, api_url_base)
-                    except Exception as exc:
-                        # Don't crash the org over a probe failure; treat as 0 and let
-                        # _emit_window's retry/skip handle the subsequent fetch.
-                        self.logger.warning("Day-count probe failed for %s: %s", day_query, str(exc)[:140])
-                        day_count = 0
-                    if day_count >= self.DAY_PREFLIGHT_CAP:
+                    # Peak-day pre-flight: if a single day exceeds the 1000-result
+                    # search cap, pagination silently truncates. Fail the partition
+                    # when the probe cannot establish safety.
+                    day_count = self._search_aggregate_count(day_query, api_url_base)
+                    if day_count > self.DAY_PREFLIGHT_CAP:
                         self._skipped_windows += 1
                         self.logger.error(
-                            "SKIPPING day-window: count=%d >= cap=%d (search would silently truncate). "
+                            "SKIPPING day-window: count=%d > cap=%d (search would silently truncate). "
                             "Sub-slice by repo or refine the query. Window: %s",
                             day_count, self.DAY_PREFLIGHT_CAP, day_query,
                         )
@@ -903,33 +968,16 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
 
 VALID_STREAM_MODES = frozenset({None, "pr_velocity"})
 
-# Hosts the tap is permitted to talk to. Defense-in-depth against a misconfigured
-# scope pointing the GraphQL/REST clients at an unintended endpoint (SSRF). The
-# operator config provides api_url_base; this list is the trusted set.
-VALID_API_HOSTS = frozenset({
-    "api.github.com",       # github.com public
-    "github.a8c.com",       # Automattic GHES
-    "github.tumblr.net",    # Tumblr GHES
-})
-
 
 def validate_scope(scope: dict) -> list[str]:
     """Validate top-level scope settings (one check per scope, not per stream)."""
     errors = []
     api_url_base = scope.get("api_url_base")
     if api_url_base:
-        parsed = urlparse(api_url_base)
-        if parsed.scheme != "https":
-            errors.append(
-                f"api_url_base {api_url_base!r} must use https (got scheme={parsed.scheme!r})"
-            )
-        elif not parsed.hostname:
-            errors.append(f"api_url_base {api_url_base!r} has no hostname")
-        elif parsed.hostname not in VALID_API_HOSTS:
-            errors.append(
-                f"api_url_base host {parsed.hostname!r} not in allowlist "
-                f"{sorted(VALID_API_HOSTS)}; add the host to VALID_API_HOSTS if new"
-            )
+        try:
+            normalize_api_base_url(api_url_base)
+        except ValueError as exc:
+            errors.append(str(exc))
     return errors
 
 
@@ -952,22 +1000,37 @@ def validate_stream_config(stream_config: dict) -> list[str]:
             f"Unknown mode {mode!r}: expected one of {sorted(repr(m) for m in VALID_STREAM_MODES)} "
             f"(omit `mode` for the default count stream)"
         )
+    if mode == "pr_velocity":
+        query_template_lower = query_template.lower()
+        if not re.search(r"\b(?:type|is):pr\b", query_template_lower):
+            errors.append("pr_velocity query_template must include type:pr or is:pr")
+        if "closed:{start}..{end}" not in query_template_lower:
+            errors.append("pr_velocity query_template must include closed:{start}..{end}")
     return errors
 
 
-def _decode_search_config(tap) -> dict | None:
+def _decode_search_config() -> dict | None:
     """Simple configuration loading from environment variable."""
+    search_b64 = os.getenv("TAP_GITHUB_SEARCH_CONFIG_B64")
     search_json = os.getenv("TAP_GITHUB_SEARCH_CONFIG")
+    if search_b64 and search_json:
+        raise ValueError(
+            "Both TAP_GITHUB_SEARCH_CONFIG and TAP_GITHUB_SEARCH_CONFIG_B64 are set. "
+            "Please use only one."
+        )
+    if search_b64:
+        search_json = base64.b64decode(search_b64).decode("utf-8")
     if search_json:
         return json.loads(search_json)
+    return None
 
 
 def create_configurable_streams(tap, config_override: dict | None = None) -> list:
-    streams: list[ConfigurableSearchCountStream] = []
+    streams: list[SearchCountStreamBase] = []
     config = config_override or tap.config
     
     # Try to get search config from environment variables first
-    env_search_config = _decode_search_config(tap)
+    env_search_config = _decode_search_config()
     if env_search_config:
         tap.logger.info("Using search configuration from environment variables")
         config = dict(config)  # Make a copy

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -471,6 +471,250 @@ class ConfigurableSearchCountStream(SearchCountStreamBase):
         return partitions
 
 
+def _instance_from_api_base(api_url_base: str) -> str:
+    base = (api_url_base or "").lower()
+    if "github.a8c.com" in base:
+        return "a8c_ghe"
+    if "github.tumblr.net" in base:
+        return "tumblr_ghe"
+    if "api.github.com" in base or "github.com" in base:
+        return "github_com"
+    return "unknown"
+
+
+CLOSED_RANGE_RE = re.compile(r"closed:\d{4}-\d{2}-\d{2}\.\.\d{4}-\d{2}-\d{2}")
+CLOSED_CAPTURE_RE = re.compile(r"closed:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})")
+
+
+def _hours_between(created: str | None, closed: str | None) -> float | None:
+    if not created or not closed:
+        return None
+    c0 = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    c1 = datetime.fromisoformat(closed.replace("Z", "+00:00"))
+    return round((c1 - c0).total_seconds() / 3600.0, 4)
+
+
+class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
+    """Per-PR velocity stream: one row per closed PR with timing + AI cohort flags.
+
+    Reuses the count stream's transport, auth, monthly partitioning and _search_cfg
+    injection; overrides the schema and get_records to emit per-PR rows. The base
+    is:closed query is day-sliced to stay under the 1000-result search cap, and AI
+    membership is folded into is_ai_authored / is_ai_reviewed booleans before emit.
+    """
+
+    replication_method: ClassVar[str] = "FULL_TABLE"
+    replication_key = None
+    primary_keys: ClassVar[list[str]] = ["instance", "org", "repo", "pr_number"]
+    state_partitioning_keys: ClassVar[list[str]] = []
+
+    GRAPHQL_PR_VELOCITY: ClassVar[str] = """
+    query PrVelocity($q: String!, $after: String) {
+      search(query: $q, type: ISSUE, first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ... on PullRequest {
+            number title url state isDraft
+            createdAt closedAt mergedAt updatedAt
+            author { login }
+            mergedBy { login }
+            repository { name nameWithOwner }
+            baseRefName headRefName
+            additions deletions changedFiles
+            reviewDecision
+            comments { totalCount }
+            reviews { totalCount }
+            commits { totalCount }
+            labels(first: 10) { nodes { name } }
+          }
+        }
+      }
+      rateLimit { cost remaining }
+    }
+    """
+
+    GRAPHQL_PR_IDS: ClassVar[str] = """
+    query PrIds($q: String!, $after: String) {
+      search(query: $q, type: ISSUE, first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { ... on PullRequest { number repository { nameWithOwner } } }
+      }
+      rateLimit { cost remaining }
+    }
+    """
+
+    def __init__(self, stream_config: dict, tap):
+        self.stream_config = stream_config
+        self.query_template = stream_config["query_template"]
+        self.stream_description = stream_config.get("description", f"PR velocity stream: {stream_config['name']}")
+        self.name = stream_config["name"]
+        self.stream_type = stream_config.get("stream_type", stream_config.get("name", "pr_velocity"))
+        self.tap = tap
+        # Skip ConfigurableSearchCountStream.__init__ (it forces the *_search_counts name + count schema).
+        SearchCountStreamBase.__init__(self, tap=tap, name=self.name, schema=self.get_schema())
+
+    @classmethod
+    def get_schema(cls) -> dict:
+        return th.PropertiesList(
+            th.Property("instance", th.StringType, required=True),
+            th.Property("org", th.StringType, required=True),
+            th.Property("repo", th.StringType, required=True),
+            th.Property("pr_number", th.IntegerType, required=True),
+            th.Property("title", th.StringType),
+            th.Property("url", th.StringType),
+            th.Property("author_login", th.StringType),
+            th.Property("created_at", th.DateTimeType),
+            th.Property("merged_at", th.DateTimeType),
+            th.Property("closed_at", th.DateTimeType),
+            th.Property("updated_at", th.DateTimeType),
+            th.Property("hours_to_close", th.NumberType),
+            th.Property("outcome", th.StringType),
+            th.Property("state", th.StringType),
+            th.Property("is_draft", th.BooleanType),
+            th.Property("merged_by_login", th.StringType),
+            th.Property("base_ref", th.StringType),
+            th.Property("head_ref", th.StringType),
+            th.Property("additions", th.IntegerType),
+            th.Property("deletions", th.IntegerType),
+            th.Property("changed_files", th.IntegerType),
+            th.Property("review_decision", th.StringType),
+            th.Property("comment_count", th.IntegerType),
+            th.Property("review_count", th.IntegerType),
+            th.Property("commit_count", th.IntegerType),
+            th.Property("label_names", th.ArrayType(th.StringType)),
+            th.Property("is_ai_authored", th.BooleanType),
+            th.Property("is_ai_reviewed", th.BooleanType),
+            th.Property("month", th.StringType),
+            th.Property("synced_at", th.DateTimeType),
+        ).to_dict()
+
+    def _scope(self) -> dict:
+        cfg_source = getattr(self, "_search_cfg", None) or self.config
+        return cfg_source.get("search", {}).get("scope", {})
+
+    def _iter_pr_nodes(self, query: str, api_url_base: str):
+        after = None
+        skipped = 0
+        seen_any = False
+        while True:
+            resp = self._make_graphql_request(self.GRAPHQL_PR_VELOCITY, {"q": query, "after": after}, api_url_base)
+            search = resp.json()["data"]["search"]
+            for node in search["nodes"]:
+                if not node or node.get("number") is None or not node.get("repository"):
+                    skipped += 1
+                    continue
+                seen_any = True
+                yield node
+            if not search["pageInfo"]["hasNextPage"]:
+                break
+            after = search["pageInfo"]["endCursor"]
+        if skipped and not seen_any:
+            raise RuntimeError(f"All {skipped} node(s) skipped for query: {query} -- token may lack repo access")
+
+    def _collect_pr_ids(self, query: str, api_url_base: str) -> set:
+        ids: set = set()
+        after = None
+        while True:
+            resp = self._make_graphql_request(self.GRAPHQL_PR_IDS, {"q": query, "after": after}, api_url_base)
+            search = resp.json()["data"]["search"]
+            for node in search["nodes"]:
+                if node and node.get("number") is not None and node.get("repository"):
+                    ids.add(f"{node['repository']['nameWithOwner']}#{node['number']}")
+            if not search["pageInfo"]["hasNextPage"]:
+                break
+            after = search["pageInfo"]["endCursor"]
+        return ids
+
+    def _iter_day_queries(self, query: str):
+        m = CLOSED_CAPTURE_RE.search(query)
+        if not m:
+            yield query
+            return
+        start = datetime.strptime(m.group(1), "%Y-%m-%d")
+        end = datetime.strptime(m.group(2), "%Y-%m-%d")
+        cur = start
+        while cur <= end:
+            day = cur.strftime("%Y-%m-%d")
+            yield CLOSED_RANGE_RE.sub(f"closed:{day}..{day}", query)
+            cur += timedelta(days=1)
+
+    def _node_to_row(self, node: dict, instance: str, org: str, month: str, now: str) -> dict:
+        repo_full = node["repository"]["nameWithOwner"]
+        repo_name = node["repository"].get("name") or repo_full.split("/")[-1]
+        merged_at = node.get("mergedAt")
+        labels = [l["name"] for l in ((node.get("labels") or {}).get("nodes") or []) if l]
+        author = node.get("author") or {}
+        merged_by = node.get("mergedBy") or {}
+        return {
+            "instance": instance,
+            "org": org,
+            "repo": repo_name,
+            "pr_number": node["number"],
+            "title": node.get("title"),
+            "url": node.get("url"),
+            "author_login": author.get("login"),
+            "created_at": node.get("createdAt"),
+            "merged_at": merged_at,
+            "closed_at": node.get("closedAt"),
+            "updated_at": node.get("updatedAt"),
+            "hours_to_close": _hours_between(node.get("createdAt"), node.get("closedAt")),
+            "outcome": "merged" if merged_at else "closed_unmerged",
+            "state": node.get("state"),
+            "is_draft": node.get("isDraft"),
+            "merged_by_login": merged_by.get("login"),
+            "base_ref": node.get("baseRefName"),
+            "head_ref": node.get("headRefName"),
+            "additions": node.get("additions"),
+            "deletions": node.get("deletions"),
+            "changed_files": node.get("changedFiles"),
+            "review_decision": node.get("reviewDecision"),
+            "comment_count": (node.get("comments") or {}).get("totalCount"),
+            "review_count": (node.get("reviews") or {}).get("totalCount"),
+            "commit_count": (node.get("commits") or {}).get("totalCount"),
+            "label_names": labels,
+            "is_ai_authored": False,
+            "is_ai_reviewed": False,
+            "month": month,
+            "synced_at": now,
+        }
+
+    def _process_window(self, window_query, api_url_base, instance, org, month, now, markers, reviewer):
+        ai_authored_ids: set = set()
+        for marker in markers:
+            ai_authored_ids |= self._collect_pr_ids(f"{window_query} {marker}", api_url_base)
+        ai_reviewed_ids = self._collect_pr_ids(f"{window_query} {reviewer}", api_url_base) if reviewer else set()
+        for node in self._iter_pr_nodes(window_query, api_url_base):
+            row = self._node_to_row(node, instance, org, month, now)
+            key = f"{node['repository']['nameWithOwner']}#{node['number']}"
+            row["is_ai_authored"] = key in ai_authored_ids
+            row["is_ai_reviewed"] = key in ai_reviewed_ids
+            yield row
+
+    def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
+        now = datetime.utcnow().isoformat() + "Z"
+        partitions_to_process = [context] if context else self.partitions
+        markers = self.stream_config.get("markers", []) or []
+        reviewer = self.stream_config.get("reviewer_clause", "") or ""
+        for partition in partitions_to_process:
+            org = partition["org"]
+            month = partition["month"]
+            query = partition["search_query"]
+            api_url_base = partition["api_url_base"]
+            instance = self._scope().get("instance") or _instance_from_api_base(api_url_base)
+            # Adaptive granularity: only day-slice a month when it would exceed the
+            # 1000-result search cap. A month with <= cap results is fully retrievable
+            # in one windowed (paginated) pass, which avoids days x clauses query blow-up.
+            month_count = self._search_aggregate_count(query, api_url_base)
+            if month_count == 0:
+                continue
+            if month_count <= NODES_THRESHOLD:
+                yield from self._process_window(query, api_url_base, instance, org, month, now, markers, reviewer)
+            else:
+                self.logger.info("Month %s for %s has %d > %d results; day-slicing.", month, org, month_count, NODES_THRESHOLD)
+                for day_query in self._iter_day_queries(query):
+                    yield from self._process_window(day_query, api_url_base, instance, org, month, now, markers, reviewer)
+
+
 def validate_stream_config(stream_config: dict) -> list[str]:
     errors = []
     required_fields = ["name", "query_template"]
@@ -512,12 +756,18 @@ def create_configurable_streams(tap, config_override: dict | None = None) -> lis
                 "name": sd.get("name"),
                 "query_template": sd.get("query_template"),
                 "description": sd.get("description"),
+                "mode": sd.get("mode"),
+                "markers": sd.get("markers", []),
+                "reviewer_clause": sd.get("reviewer_clause", ""),
             }
             errors = validate_stream_config(sc)
             if errors:
                 tap.logger.warning(f"Invalid stream config '{sc.get('name', 'unknown')}': {'; '.join(errors)}")
                 continue
-            streams.append(ConfigurableSearchCountStream(sc, tap))
+            if sd.get("mode") == "pr_velocity":
+                streams.append(ConfigurablePrVelocityStream(sc, tap))
+            else:
+                streams.append(ConfigurableSearchCountStream(sc, tap))
     else:
         tap.logger.warning("No search configuration found")
     if not streams:

--- a/tap_github_search/tap.py
+++ b/tap_github_search/tap.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
-import base64
-import json
-import os
+
 from singer_sdk import Stream
 from tap_github.tap import TapGitHub
 from tap_github_search.search_count_streams import (
+    _decode_search_config,
     create_configurable_streams,
-    ConfigurableSearchCountStream,
 )
 
 
@@ -14,28 +12,18 @@ class TapGitHubSearch(TapGitHub):
     name = "tap-github-search"
 
     def discover_streams(self) -> list[Stream]:
-        search_cfg_b64 = os.environ.get("TAP_GITHUB_SEARCH_CONFIG_B64")
-        search_cfg = os.environ.get("TAP_GITHUB_SEARCH_CONFIG")
-        
-        # Ensure both env vars aren't set simultaneously
-        if search_cfg_b64 and search_cfg:
-            raise ValueError("Both TAP_GITHUB_SEARCH_CONFIG and TAP_GITHUB_SEARCH_CONFIG_B64 are set. Please use only one.")
-        
-        if search_cfg_b64:
-            search_cfg = base64.b64decode(search_cfg_b64).decode("utf-8")
-            self.logger.debug(f"Decoded TAP_GITHUB_SEARCH_CONFIG_B64: {search_cfg}")
-        
-        if not search_cfg and not search_cfg_b64 and "search" not in self.config:
+        env_search_config = _decode_search_config()
+
+        if not env_search_config and "search" not in self.config:
             raise ValueError("Provide search.* in config, set TAP_GITHUB_SEARCH_CONFIG, or set TAP_GITHUB_SEARCH_CONFIG_B64.")
 
         cfg = dict(self.config)
-        if "search" not in cfg and search_cfg:
-            cfg["search"] = json.loads(search_cfg)
+        if env_search_config:
+            cfg["search"] = env_search_config
 
         streams = create_configurable_streams(self, config_override=cfg)
         for s in streams:
-            if isinstance(s, ConfigurableSearchCountStream):
-                setattr(s, "_search_cfg", {"search": cfg["search"]})
+            setattr(s, "_search_cfg", {"search": cfg["search"]})
         return streams
 
 

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -7,6 +7,8 @@ handling, and mode dispatch -- the code paths the review flagged as risky.
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -20,7 +22,6 @@ from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
     NODES_THRESHOLD,
     VALID_API_HOSTS,
-    VALID_STREAM_MODES,
     _hours_between,
     _instance_from_api_base,
     _is_transient_graphql_failure,
@@ -28,6 +29,7 @@ from tap_github_search.search_count_streams import (
     validate_scope,
     validate_stream_config,
 )
+from tap_github_search.tap import TapGitHubSearch
 
 
 # ---------- helpers ----------
@@ -202,6 +204,18 @@ class TestEmitWindow:
         assert result == []
         assert stream._skipped_windows == 1
 
+    def test_propagates_rate_limit_without_skip(self):
+        stream = _mk_velocity()
+        stream._skipped_windows = 0
+        rate_limited = _fatal_with_response(
+            200,
+            payload={"errors": [{"type": "RATE_LIMITED", "message": "rate limit"}]},
+        )
+        with patch.object(stream, "_process_window", side_effect=rate_limited):
+            with pytest.raises(FatalAPIError):
+                stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+        assert stream._skipped_windows == 0
+
     def test_propagates_non_transient(self):
         """Genuine bugs (KeyError, auth) must NOT be silently skipped."""
         stream = _mk_velocity()
@@ -267,11 +281,11 @@ class TestGetRecordsDispatch:
         assert "closed:2026-01-01..2026-01-01" in first_day_query
 
     def test_skips_day_exceeding_preflight_cap(self):
-        """P0 #B1 -- if a day's issueCount is at/above DAY_PREFLIGHT_CAP, skip+log
+        """P0 #B1 -- if a day's issueCount is above DAY_PREFLIGHT_CAP, skip+log
         rather than silently truncate at the 1000-result search cap."""
         stream = _mk_velocity()
         # month-count > threshold (forces day-slicing), then one busy day, then small ones
-        day_counts = [NODES_THRESHOLD + 100] + [950] + [5] * 30
+        day_counts = [NODES_THRESHOLD + 100] + [NODES_THRESHOLD + 1] + [5] * 30
         with patch.object(stream, "_search_aggregate_count", side_effect=day_counts), \
              patch.object(stream, "_emit_window", return_value=[]) as fake_emit:
             partition = {
@@ -284,6 +298,69 @@ class TestGetRecordsDispatch:
         # 30 emit calls (busy day skipped), and the counter records the skip
         assert fake_emit.call_count == 30
         assert stream._skipped_windows == 1
+
+    def test_failed_day_count_probe_fails_partition(self):
+        stream = _mk_velocity()
+        with patch.object(
+            stream,
+            "_search_aggregate_count",
+            side_effect=[NODES_THRESHOLD + 1, RetriableAPIError("502", Mock(status_code=502))],
+        ), patch.object(stream, "_emit_window") as fake_emit:
+            partition = {
+                "org": "test-org",
+                "month": "2026-01",
+                "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
+                "api_url_base": "https://api.github.com",
+            }
+            with pytest.raises(RetriableAPIError):
+                list(stream.get_records(partition))
+        fake_emit.assert_not_called()
+
+
+class TestProcessWindow:
+    def test_body_markers_and_reviewer_clause_set_flags(self):
+        stream = _mk_velocity(
+            markers=['"Generated with Claude Code"', "openai-codex"],
+            reviewer="reviewed-by:claude[bot]",
+        )
+        nodes = [
+            {
+                "number": 1,
+                "repository": {"nameWithOwner": "test-org/repo", "name": "repo"},
+                "createdAt": "2026-04-01T00:00:00Z",
+                "closedAt": "2026-04-01T01:00:00Z",
+                "mergedAt": "2026-04-01T01:00:00Z",
+                "bodyText": "This was generated with claude code.",
+            },
+            {
+                "number": 2,
+                "repository": {"nameWithOwner": "test-org/repo", "name": "repo"},
+                "createdAt": "2026-04-01T00:00:00Z",
+                "closedAt": "2026-04-01T02:00:00Z",
+                "mergedAt": None,
+                "bodyText": "Hand-authored PR.",
+            },
+        ]
+        with patch.object(stream, "_iter_pr_nodes", return_value=iter(nodes)), \
+             patch.object(stream, "_collect_pr_ids", return_value={"test-org/repo#2"}) as collect_ids:
+            rows = list(
+                stream._process_window(
+                    "org:test-org type:pr is:closed closed:2026-04-01..2026-04-01",
+                    "https://api.github.com",
+                    "github_com",
+                    "test-org",
+                    "2026-04",
+                    "now",
+                    stream.stream_config["markers"],
+                    stream.stream_config["reviewer_clause"],
+                )
+            )
+
+        collect_ids.assert_called_once()
+        assert rows[0]["is_ai_authored"] is True
+        assert rows[0]["is_ai_reviewed"] is False
+        assert rows[1]["is_ai_authored"] is False
+        assert rows[1]["is_ai_reviewed"] is True
 
 
 class TestNodeToRow:
@@ -390,6 +467,22 @@ class TestValidateStreamConfig:
         })
         assert any("Unknown mode" in e for e in errs)
 
+    def test_rejects_pr_velocity_without_closed_range(self):
+        errs = validate_stream_config({
+            "name": "x",
+            "query_template": "org:{org} type:pr is:closed created:{start}..{end}",
+            "mode": "pr_velocity",
+        })
+        assert any("closed:{start}..{end}" in e for e in errs)
+
+    def test_rejects_pr_velocity_without_pr_qualifier(self):
+        errs = validate_stream_config({
+            "name": "x",
+            "query_template": "org:{org} is:closed closed:{start}..{end}",
+            "mode": "pr_velocity",
+        })
+        assert any("type:pr or is:pr" in e for e in errs)
+
 
 class TestValidateScope:
     """SSRF allowlist on api_url_base. Defense-in-depth against scope misconfig."""
@@ -436,7 +529,16 @@ class TestValidateScope:
             _search_cfg={"search": {"scope": {"api_url_base": "https://evil.example.com"}}},
             config={},
         )
-        with pytest.raises(ValueError, match="Refusing to authenticate"):
+        with pytest.raises(ValueError, match="not in allowlist"):
+            WrapperGitHubTokenAuthenticator._extract_api_base_url_from_stream(stream)
+
+    def test_authenticator_rejects_non_https_allowlisted_host(self):
+        from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
+        stream = SimpleNamespace(
+            _search_cfg={"search": {"scope": {"api_url_base": "http://api.github.com"}}},
+            config={},
+        )
+        with pytest.raises(ValueError, match="must use https"):
             WrapperGitHubTokenAuthenticator._extract_api_base_url_from_stream(stream)
 
     def test_authenticator_accepts_allowlisted_host(self):
@@ -448,3 +550,32 @@ class TestValidateScope:
             )
             url = WrapperGitHubTokenAuthenticator._extract_api_base_url_from_stream(stream)
             assert host in url
+
+
+class TestEnvConfig:
+    def test_b64_config_overrides_existing_search_config(self, monkeypatch):
+        file_search = {
+            "streams": [{
+                "name": "file",
+                "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+                "mode": "pr_velocity",
+            }],
+            "scope": {"api_url_base": "https://api.github.com", "orgs": ["file-org"]},
+            "backfill": {"start_month": "2026-04"},
+        }
+        env_search = {
+            "streams": [{
+                "name": "env",
+                "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+                "mode": "pr_velocity",
+            }],
+            "scope": {"api_url_base": "https://api.github.com", "orgs": ["env-org"]},
+            "backfill": {"start_month": "2026-04"},
+        }
+        encoded = base64.b64encode(json.dumps(env_search).encode()).decode()
+        monkeypatch.setenv("TAP_GITHUB_SEARCH_CONFIG_B64", encoded)
+
+        tap = TapGitHubSearch(config={"search": file_search})
+        streams = tap.discover_streams()
+
+        assert streams[0].stream_config["name"] == "env"

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -1,0 +1,389 @@
+"""Unit tests for ConfigurablePrVelocityStream and its helpers.
+
+P0 set per the pre-cluster review (see PR #12 description). Covers exception
+classification, retry semantics, skip-vs-propagate, day-slicing math, null-node
+handling, and mode dispatch -- the code paths the review flagged as risky.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
+
+from tap_github_search.search_count_streams import (
+    ConfigurablePrVelocityStream,
+    ConfigurableSearchCountStream,
+    NODES_THRESHOLD,
+    VALID_STREAM_MODES,
+    _hours_between,
+    _instance_from_api_base,
+    _is_transient_graphql_failure,
+    create_configurable_streams,
+    validate_stream_config,
+)
+
+
+# ---------- helpers ----------
+
+class _DummyTap:
+    """Minimal tap shim. Mirrors the pattern in test_search_count_streams.py."""
+
+    config: dict = {}
+    state: dict = {}
+    logger = logging.getLogger("dummy_tap")
+    metrics_logger = logging.getLogger("dummy_metrics")
+    name = "dummy_tap"
+    initialized_at = 0
+    rate_limit_buffer = 0
+
+    def setup_mapper(self):
+        pass
+
+
+def _mk_velocity(*, name="pr_velocity", markers=None, reviewer="", instance="github_com"):
+    """Build a ConfigurablePrVelocityStream attached to a dummy tap."""
+    cfg = {
+        "name": name,
+        "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+        "mode": "pr_velocity",
+        "markers": markers or [],
+        "reviewer_clause": reviewer,
+    }
+    tap = _DummyTap()
+    stream = ConfigurablePrVelocityStream(cfg, tap)
+    # Inject the search config the way tap.py does for real runs
+    stream._search_cfg = {
+        "search": {
+            "scope": {
+                "api_url_base": "https://api.github.com",
+                "orgs": ["test-org"],
+                "instance": instance,
+            },
+            "backfill": {"start_month": "2026-04"},
+        }
+    }
+    return stream
+
+
+def _fatal_with_response(status_code: int, body_text: str = "", payload: dict | None = None):
+    """Build a FatalAPIError carrying a Response-like object.
+
+    Different singer-sdk versions vary on whether the response is auto-attached as
+    `.response`; set it explicitly so the test is version-independent.
+    """
+    resp = Mock()
+    resp.status_code = status_code
+    resp.text = body_text
+    resp.json = Mock(return_value=payload if payload is not None else {})
+    exc = FatalAPIError("Graphql error: synthetic")
+    exc.response = resp
+    return exc
+
+
+# ---------- P0 tests ----------
+
+class TestIsTransientGraphqlFailure:
+    """P0 #1 -- classification correctness for the retry/skip filter."""
+
+    def test_retriable_api_error_is_transient(self):
+        assert _is_transient_graphql_failure(RetriableAPIError("503", Mock(status_code=503))) is True
+
+    def test_request_exception_is_transient(self):
+        assert _is_transient_graphql_failure(requests.exceptions.ConnectionError("boom")) is True
+
+    def test_fatal_with_internal_error_type_is_transient(self):
+        exc = _fatal_with_response(
+            200,
+            payload={"errors": [{"type": "INTERNAL", "message": "Something went wrong"}]},
+        )
+        assert _is_transient_graphql_failure(exc) is True
+
+    def test_fatal_with_rate_limited_error_type_is_transient(self):
+        exc = _fatal_with_response(
+            200,
+            payload={"errors": [{"type": "RATE_LIMITED", "message": "API rate limit"}]},
+        )
+        assert _is_transient_graphql_failure(exc) is True
+
+    def test_fatal_with_forbidden_is_fail_fast(self):
+        """SAML / classic-PAT block (e.g. WooCommerce) -- permanent, must NOT retry."""
+        exc = _fatal_with_response(
+            200,
+            payload={"errors": [{"type": "FORBIDDEN", "message": "org forbids access"}]},
+        )
+        assert _is_transient_graphql_failure(exc) is False
+
+    def test_fatal_with_bad_credentials_is_fail_fast(self):
+        exc = _fatal_with_response(401, body_text='{"message":"Bad credentials"}')
+        assert _is_transient_graphql_failure(exc) is False
+
+    def test_fatal_with_secondary_rate_limit_403_is_transient(self):
+        """The bug the review caught: secondary rate-limit returns 403 with a
+        specific message; current code shouldn't conflate it with permanent FORBIDDEN."""
+        exc = _fatal_with_response(403, body_text="You have exceeded a secondary rate limit")
+        assert _is_transient_graphql_failure(exc) is True
+
+    def test_keyerror_is_not_transient(self):
+        """Genuine code bugs must propagate, not get masked as transient."""
+        assert _is_transient_graphql_failure(KeyError("missing")) is False
+
+
+class TestRobustGraphqlRetry:
+    """P0 #2-4 -- retry/backoff/exhaustion behavior."""
+
+    def test_retries_transient_then_succeeds(self):
+        stream = _mk_velocity()
+        calls = []
+        good_resp = Mock(name="resp")
+
+        def fake_request(_query, _variables, _api):
+            calls.append(1)
+            if len(calls) < 3:
+                raise RetriableAPIError("502", Mock(status_code=502))
+            return good_resp
+
+        with patch.object(stream, "_make_graphql_request", side_effect=fake_request), \
+             patch("tap_github_search.search_count_streams.time.sleep") as fake_sleep:
+            result = stream._robust_graphql("q", {}, "https://api.github.com", tries=5, max_wall_seconds=1000)
+        assert result is good_resp
+        assert len(calls) == 3
+        assert fake_sleep.call_count == 2  # one sleep before each retry
+
+    def test_fails_fast_on_non_transient(self):
+        """4xx / auth errors must not be retried at all."""
+        stream = _mk_velocity()
+        bad = _fatal_with_response(401, body_text='{"message":"Bad credentials"}')
+        with patch.object(stream, "_make_graphql_request", side_effect=bad), \
+             patch("tap_github_search.search_count_streams.time.sleep") as fake_sleep:
+            with pytest.raises(FatalAPIError):
+                stream._robust_graphql("q", {}, "https://api.github.com", tries=5, max_wall_seconds=1000)
+        # Should have called exactly once -- no retries on non-transient
+        assert fake_sleep.call_count == 0
+
+    def test_exhausts_tries_and_raises_last_exception(self):
+        stream = _mk_velocity()
+        always_bad = RetriableAPIError("502", Mock(status_code=502))
+        with patch.object(stream, "_make_graphql_request", side_effect=always_bad), \
+             patch("tap_github_search.search_count_streams.time.sleep"):
+            with pytest.raises(RetriableAPIError):
+                stream._robust_graphql("q", {}, "https://api.github.com", tries=3, max_wall_seconds=1000)
+
+    def test_aborts_when_wall_time_budget_exceeded(self):
+        """Even if tries remain, an outage exceeding max_wall_seconds must give up."""
+        stream = _mk_velocity()
+        always_bad = RetriableAPIError("502", Mock(status_code=502))
+        # patch monotonic so first call returns 0, subsequent calls return a large value
+        with patch.object(stream, "_make_graphql_request", side_effect=always_bad), \
+             patch("tap_github_search.search_count_streams.time.sleep"), \
+             patch("tap_github_search.search_count_streams.time.monotonic",
+                   side_effect=[0, 999, 999, 999, 999, 999, 999, 999, 999, 999]):
+            with pytest.raises(RetriableAPIError):
+                stream._robust_graphql("q", {}, "https://api.github.com", tries=8, max_wall_seconds=10)
+
+
+class TestEmitWindow:
+    """P0 #5-6 -- transient errors skip the window; non-transient propagate."""
+
+    def test_skips_transient_and_increments_counter(self):
+        stream = _mk_velocity()
+        stream._skipped_windows = 0
+        with patch.object(
+            stream, "_process_window",
+            side_effect=RetriableAPIError("502", Mock(status_code=502)),
+        ):
+            result = stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+        assert result == []
+        assert stream._skipped_windows == 1
+
+    def test_propagates_non_transient(self):
+        """Genuine bugs (KeyError, auth) must NOT be silently skipped."""
+        stream = _mk_velocity()
+        stream._skipped_windows = 0
+        with patch.object(stream, "_process_window", side_effect=KeyError("not transient")):
+            with pytest.raises(KeyError):
+                stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+        assert stream._skipped_windows == 0  # counter unchanged on non-transient
+
+
+class TestGetRecordsDispatch:
+    """P0 #7-9 -- partition handling and adaptive granularity."""
+
+    def test_skips_zero_count_month(self):
+        stream = _mk_velocity()
+        with patch.object(stream, "_search_aggregate_count", return_value=0), \
+             patch.object(stream, "_emit_window") as fake_emit:
+            partition = {
+                "org": "test-org",
+                "month": "2026-04",
+                "search_query": "org:test-org type:pr is:closed closed:2026-04-01..2026-04-30",
+                "api_url_base": "https://api.github.com",
+            }
+            rows = list(stream.get_records(partition))
+        assert rows == []
+        fake_emit.assert_not_called()  # zero-count months are skipped without fetching
+
+    def test_single_window_when_under_threshold(self):
+        """Month with <= NODES_THRESHOLD results is fetched as one paginated pass."""
+        stream = _mk_velocity()
+        with patch.object(stream, "_search_aggregate_count", return_value=500), \
+             patch.object(stream, "_emit_window", return_value=[]) as fake_emit:
+            partition = {
+                "org": "test-org",
+                "month": "2026-04",
+                "search_query": "org:test-org type:pr is:closed closed:2026-04-01..2026-04-30",
+                "api_url_base": "https://api.github.com",
+            }
+            list(stream.get_records(partition))
+        # Exactly one window fetch, with the original monthly query (no day-slicing)
+        assert fake_emit.call_count == 1
+        called_query = fake_emit.call_args[0][0]
+        assert "closed:2026-04-01..2026-04-30" in called_query
+
+    def test_day_slices_when_over_threshold(self):
+        """Month exceeding NODES_THRESHOLD must day-slice; day pre-flight probes day counts."""
+        stream = _mk_velocity()
+        # First call returns month count (> threshold); subsequent calls are day-count probes (small)
+        with patch.object(
+            stream, "_search_aggregate_count",
+            side_effect=[NODES_THRESHOLD + 500] + [10] * 31,
+        ), patch.object(stream, "_emit_window", return_value=[]) as fake_emit:
+            partition = {
+                "org": "test-org",
+                "month": "2026-01",
+                "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
+                "api_url_base": "https://api.github.com",
+            }
+            list(stream.get_records(partition))
+        # 31 day-windows for January
+        assert fake_emit.call_count == 31
+        first_day_query = fake_emit.call_args_list[0][0][0]
+        assert "closed:2026-01-01..2026-01-01" in first_day_query
+
+    def test_skips_day_exceeding_preflight_cap(self):
+        """P0 #B1 -- if a day's issueCount is at/above DAY_PREFLIGHT_CAP, skip+log
+        rather than silently truncate at the 1000-result search cap."""
+        stream = _mk_velocity()
+        # month-count > threshold (forces day-slicing), then one busy day, then small ones
+        day_counts = [NODES_THRESHOLD + 100] + [950] + [5] * 30
+        with patch.object(stream, "_search_aggregate_count", side_effect=day_counts), \
+             patch.object(stream, "_emit_window", return_value=[]) as fake_emit:
+            partition = {
+                "org": "test-org",
+                "month": "2026-01",
+                "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
+                "api_url_base": "https://api.github.com",
+            }
+            list(stream.get_records(partition))
+        # 30 emit calls (busy day skipped), and the counter records the skip
+        assert fake_emit.call_count == 30
+        assert stream._skipped_windows == 1
+
+
+class TestNodeToRow:
+    """P0 #11 -- null/missing fields must not crash row construction."""
+
+    def test_handles_nulls_gracefully(self):
+        stream = _mk_velocity()
+        node = {
+            "number": 42,
+            "repository": {"nameWithOwner": "test-org/test-repo", "name": "test-repo"},
+            "createdAt": "2026-04-01T00:00:00Z",
+            "closedAt": "2026-04-02T00:00:00Z",
+            "mergedAt": None,  # closed-unmerged
+            "author": None,    # ghost user
+            "mergedBy": None,  # unmerged
+            "labels": {"nodes": [None, {"name": "bug"}, None]},  # mixed nulls
+            "title": None,
+        }
+        row = stream._node_to_row(node, "github_com", "test-org", "2026-04", "now")
+        assert row["pr_number"] == 42
+        assert row["author_login"] is None
+        assert row["merged_by_login"] is None
+        assert row["label_names"] == ["bug"]   # nulls filtered, valid kept
+        assert row["outcome"] == "closed_unmerged"  # mergedAt None -> unmerged
+        assert row["hours_to_close"] == 24.0
+        assert row["is_ai_authored"] is False
+        assert row["is_ai_reviewed"] is False
+
+
+# ---------- Bonus / supporting tests (cheap, prevent regressions) ----------
+
+class TestHoursBetween:
+    def test_handles_none(self):
+        assert _hours_between(None, "2026-04-01T00:00:00Z") is None
+        assert _hours_between("2026-04-01T00:00:00Z", None) is None
+        assert _hours_between(None, None) is None
+
+    def test_iso_with_z_suffix(self):
+        result = _hours_between("2026-04-01T00:00:00Z", "2026-04-01T12:00:00Z")
+        assert result == 12.0
+
+
+class TestInstanceFromApiBase:
+    def test_known_hosts(self):
+        assert _instance_from_api_base("https://api.github.com") == "github_com"
+        assert _instance_from_api_base("https://github.a8c.com/api/v3") == "a8c_ghe"
+        assert _instance_from_api_base("https://github.tumblr.net/api/v3") == "tumblr_ghe"
+
+    def test_unknown_falls_back(self):
+        assert _instance_from_api_base("https://example.invalid") == "unknown"
+        assert _instance_from_api_base("") == "unknown"
+
+
+class TestCreateConfigurableStreamsModeDispatch:
+    def test_dispatches_pr_velocity_mode(self):
+        tap = _DummyTap()
+        config = {
+            "search": {
+                "streams": [{
+                    "name": "vel",
+                    "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+                    "mode": "pr_velocity",
+                }],
+                "scope": {"api_url_base": "https://api.github.com", "orgs": ["x"]},
+                "backfill": {"start_month": "2026-04"},
+            }
+        }
+        streams = create_configurable_streams(tap, config_override=config)
+        assert len(streams) == 1
+        assert isinstance(streams[0], ConfigurablePrVelocityStream)
+
+    def test_count_stream_when_mode_absent(self):
+        tap = _DummyTap()
+        config = {
+            "search": {
+                "streams": [{
+                    "name": "cnt",
+                    "query_template": "org:{org} is:pr is:merged merged:{start}..{end}",
+                }],
+                "scope": {"api_url_base": "https://api.github.com", "orgs": ["x"]},
+                "backfill": {"start_month": "2026-04"},
+            }
+        }
+        streams = create_configurable_streams(tap, config_override=config)
+        assert len(streams) == 1
+        # Should be the count stream class, NOT velocity
+        assert isinstance(streams[0], ConfigurableSearchCountStream)
+        assert not isinstance(streams[0], ConfigurablePrVelocityStream)
+
+
+class TestValidateStreamConfig:
+    """H5 -- mode whitelist guards against silent typo fallback."""
+
+    def test_accepts_known_modes(self):
+        for mode in (None, "pr_velocity"):
+            errs = validate_stream_config({
+                "name": "x", "query_template": "{org} {start} {end}", "mode": mode,
+            })
+            assert not any("Unknown mode" in e for e in errs)
+
+    def test_rejects_typo_in_mode(self):
+        errs = validate_stream_config({
+            "name": "x", "query_template": "{org} {start} {end}", "mode": "pr-velocity",  # hyphen typo
+        })
+        assert any("Unknown mode" in e for e in errs)

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -426,3 +426,25 @@ class TestValidateScope:
         }
         with pytest.raises(ValueError, match="not in allowlist"):
             create_configurable_streams(tap, config_override=config)
+
+    def test_authenticator_rejects_non_allowlisted_host(self):
+        """Two-layer SSRF defense: the authenticator must refuse to emit a PAT
+        to a host outside VALID_API_HOSTS even if a stream is constructed
+        outside the create_configurable_streams factory."""
+        from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
+        stream = SimpleNamespace(
+            _search_cfg={"search": {"scope": {"api_url_base": "https://evil.example.com"}}},
+            config={},
+        )
+        with pytest.raises(ValueError, match="Refusing to authenticate"):
+            WrapperGitHubTokenAuthenticator._extract_api_base_url_from_stream(stream)
+
+    def test_authenticator_accepts_allowlisted_host(self):
+        from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
+        for host in VALID_API_HOSTS:
+            stream = SimpleNamespace(
+                _search_cfg={"search": {"scope": {"api_url_base": f"https://{host}/api/v3"}}},
+                config={},
+            )
+            url = WrapperGitHubTokenAuthenticator._extract_api_base_url_from_stream(stream)
+            assert host in url

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -17,6 +17,7 @@ import pytest
 import requests
 from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 
+from tap_github_search.github_hosts import DEFAULT_API_BASE_URL, INSTANCE_BY_API_HOST
 from tap_github_search.search_count_streams import (
     ConfigurablePrVelocityStream,
     ConfigurableSearchCountStream,
@@ -33,6 +34,10 @@ from tap_github_search.tap import TapGitHubSearch
 
 
 # ---------- helpers ----------
+
+KNOWN_API_HOST = sorted(VALID_API_HOSTS)[0]
+UNKNOWN_API_BASE_URL = "https://example.invalid/api"
+
 
 class _DummyTap:
     """Minimal tap shim. Mirrors the pattern in test_search_count_streams.py."""
@@ -64,7 +69,7 @@ def _mk_velocity(*, name="pr_velocity", markers=None, reviewer="", instance="git
     stream._search_cfg = {
         "search": {
             "scope": {
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
                 "orgs": ["test-org"],
                 "instance": instance,
             },
@@ -115,7 +120,7 @@ class TestIsTransientGraphqlFailure:
         assert _is_transient_graphql_failure(exc) is True
 
     def test_fatal_with_forbidden_is_fail_fast(self):
-        """SAML / classic-PAT block (e.g. WooCommerce) -- permanent, must NOT retry."""
+        """SAML / classic-PAT block -- permanent, must NOT retry."""
         exc = _fatal_with_response(
             200,
             payload={"errors": [{"type": "FORBIDDEN", "message": "org forbids access"}]},
@@ -153,7 +158,7 @@ class TestRobustGraphqlRetry:
 
         with patch.object(stream, "_make_graphql_request", side_effect=fake_request), \
              patch("tap_github_search.search_count_streams.time.sleep") as fake_sleep:
-            result = stream._robust_graphql("q", {}, "https://api.github.com", tries=5, max_wall_seconds=1000)
+            result = stream._robust_graphql("q", {}, DEFAULT_API_BASE_URL, tries=5, max_wall_seconds=1000)
         assert result is good_resp
         assert len(calls) == 3
         assert fake_sleep.call_count == 2  # one sleep before each retry
@@ -165,7 +170,7 @@ class TestRobustGraphqlRetry:
         with patch.object(stream, "_make_graphql_request", side_effect=bad), \
              patch("tap_github_search.search_count_streams.time.sleep") as fake_sleep:
             with pytest.raises(FatalAPIError):
-                stream._robust_graphql("q", {}, "https://api.github.com", tries=5, max_wall_seconds=1000)
+                stream._robust_graphql("q", {}, DEFAULT_API_BASE_URL, tries=5, max_wall_seconds=1000)
         # Should have called exactly once -- no retries on non-transient
         assert fake_sleep.call_count == 0
 
@@ -175,7 +180,7 @@ class TestRobustGraphqlRetry:
         with patch.object(stream, "_make_graphql_request", side_effect=always_bad), \
              patch("tap_github_search.search_count_streams.time.sleep"):
             with pytest.raises(RetriableAPIError):
-                stream._robust_graphql("q", {}, "https://api.github.com", tries=3, max_wall_seconds=1000)
+                stream._robust_graphql("q", {}, DEFAULT_API_BASE_URL, tries=3, max_wall_seconds=1000)
 
     def test_aborts_when_wall_time_budget_exceeded(self):
         """Even if tries remain, an outage exceeding max_wall_seconds must give up."""
@@ -187,7 +192,7 @@ class TestRobustGraphqlRetry:
              patch("tap_github_search.search_count_streams.time.monotonic",
                    side_effect=[0, 999, 999, 999, 999, 999, 999, 999, 999, 999]):
             with pytest.raises(RetriableAPIError):
-                stream._robust_graphql("q", {}, "https://api.github.com", tries=8, max_wall_seconds=10)
+                stream._robust_graphql("q", {}, DEFAULT_API_BASE_URL, tries=8, max_wall_seconds=10)
 
 
 class TestEmitWindow:
@@ -200,7 +205,7 @@ class TestEmitWindow:
             stream, "_process_window",
             side_effect=RetriableAPIError("502", Mock(status_code=502)),
         ):
-            result = stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+            result = stream._emit_window("q", DEFAULT_API_BASE_URL, "github_com", "org", "2026-04", "now", [], "")
         assert result == []
         assert stream._skipped_windows == 1
 
@@ -213,7 +218,7 @@ class TestEmitWindow:
         )
         with patch.object(stream, "_process_window", side_effect=rate_limited):
             with pytest.raises(FatalAPIError):
-                stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+                stream._emit_window("q", DEFAULT_API_BASE_URL, "github_com", "org", "2026-04", "now", [], "")
         assert stream._skipped_windows == 0
 
     def test_propagates_non_transient(self):
@@ -222,7 +227,7 @@ class TestEmitWindow:
         stream._skipped_windows = 0
         with patch.object(stream, "_process_window", side_effect=KeyError("not transient")):
             with pytest.raises(KeyError):
-                stream._emit_window("q", "https://api.github.com", "github_com", "org", "2026-04", "now", [], "")
+                stream._emit_window("q", DEFAULT_API_BASE_URL, "github_com", "org", "2026-04", "now", [], "")
         assert stream._skipped_windows == 0  # counter unchanged on non-transient
 
 
@@ -237,7 +242,7 @@ class TestGetRecordsDispatch:
                 "org": "test-org",
                 "month": "2026-04",
                 "search_query": "org:test-org type:pr is:closed closed:2026-04-01..2026-04-30",
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
             }
             rows = list(stream.get_records(partition))
         assert rows == []
@@ -252,7 +257,7 @@ class TestGetRecordsDispatch:
                 "org": "test-org",
                 "month": "2026-04",
                 "search_query": "org:test-org type:pr is:closed closed:2026-04-01..2026-04-30",
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
             }
             list(stream.get_records(partition))
         # Exactly one window fetch, with the original monthly query (no day-slicing)
@@ -272,7 +277,7 @@ class TestGetRecordsDispatch:
                 "org": "test-org",
                 "month": "2026-01",
                 "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
             }
             list(stream.get_records(partition))
         # 31 day-windows for January
@@ -292,7 +297,7 @@ class TestGetRecordsDispatch:
                 "org": "test-org",
                 "month": "2026-01",
                 "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
             }
             list(stream.get_records(partition))
         # 30 emit calls (busy day skipped), and the counter records the skip
@@ -310,7 +315,7 @@ class TestGetRecordsDispatch:
                 "org": "test-org",
                 "month": "2026-01",
                 "search_query": "org:test-org type:pr is:closed closed:2026-01-01..2026-01-31",
-                "api_url_base": "https://api.github.com",
+                "api_url_base": DEFAULT_API_BASE_URL,
             }
             with pytest.raises(RetriableAPIError):
                 list(stream.get_records(partition))
@@ -346,7 +351,7 @@ class TestProcessWindow:
             rows = list(
                 stream._process_window(
                     "org:test-org type:pr is:closed closed:2026-04-01..2026-04-01",
-                    "https://api.github.com",
+                    DEFAULT_API_BASE_URL,
                     "github_com",
                     "test-org",
                     "2026-04",
@@ -405,9 +410,8 @@ class TestHoursBetween:
 
 class TestInstanceFromApiBase:
     def test_known_hosts(self):
-        assert _instance_from_api_base("https://api.github.com") == "github_com"
-        assert _instance_from_api_base("https://github.a8c.com/api/v3") == "a8c_ghe"
-        assert _instance_from_api_base("https://github.tumblr.net/api/v3") == "tumblr_ghe"
+        for host, instance in INSTANCE_BY_API_HOST.items():
+            assert _instance_from_api_base(f"https://{host}/api/v3") == instance
 
     def test_unknown_falls_back(self):
         assert _instance_from_api_base("https://example.invalid") == "unknown"
@@ -424,7 +428,7 @@ class TestCreateConfigurableStreamsModeDispatch:
                     "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
                     "mode": "pr_velocity",
                 }],
-                "scope": {"api_url_base": "https://api.github.com", "orgs": ["x"]},
+                "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["x"]},
                 "backfill": {"start_month": "2026-04"},
             }
         }
@@ -440,7 +444,7 @@ class TestCreateConfigurableStreamsModeDispatch:
                     "name": "cnt",
                     "query_template": "org:{org} is:pr is:merged merged:{start}..{end}",
                 }],
-                "scope": {"api_url_base": "https://api.github.com", "orgs": ["x"]},
+                "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["x"]},
                 "backfill": {"start_month": "2026-04"},
             }
         }
@@ -493,15 +497,15 @@ class TestValidateScope:
             assert errs == [], f"unexpected errors for known host {host}: {errs}"
 
     def test_rejects_unknown_host(self):
-        errs = validate_scope({"api_url_base": "https://evil.example.com/api"})
+        errs = validate_scope({"api_url_base": UNKNOWN_API_BASE_URL})
         assert any("not in allowlist" in e for e in errs)
 
     def test_rejects_http_scheme(self):
-        errs = validate_scope({"api_url_base": "http://api.github.com"})
+        errs = validate_scope({"api_url_base": f"http://{KNOWN_API_HOST}"})
         assert any("must use https" in e for e in errs)
 
     def test_allows_missing_api_url_base(self):
-        # api_url_base is optional; partitions() falls back to https://api.github.com
+        # api_url_base is optional; partitions() falls back to the default public API base.
         assert validate_scope({}) == []
 
     def test_create_configurable_streams_raises_on_bad_scope(self):
@@ -513,7 +517,7 @@ class TestValidateScope:
                     "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
                     "mode": "pr_velocity",
                 }],
-                "scope": {"api_url_base": "https://evil.example.com", "orgs": ["x"]},
+                "scope": {"api_url_base": UNKNOWN_API_BASE_URL, "orgs": ["x"]},
                 "backfill": {"start_month": "2026-04"},
             }
         }
@@ -526,7 +530,7 @@ class TestValidateScope:
         outside the create_configurable_streams factory."""
         from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
         stream = SimpleNamespace(
-            _search_cfg={"search": {"scope": {"api_url_base": "https://evil.example.com"}}},
+            _search_cfg={"search": {"scope": {"api_url_base": UNKNOWN_API_BASE_URL}}},
             config={},
         )
         with pytest.raises(ValueError, match="not in allowlist"):
@@ -535,7 +539,7 @@ class TestValidateScope:
     def test_authenticator_rejects_non_https_allowlisted_host(self):
         from tap_github_search.authenticator import WrapperGitHubTokenAuthenticator
         stream = SimpleNamespace(
-            _search_cfg={"search": {"scope": {"api_url_base": "http://api.github.com"}}},
+            _search_cfg={"search": {"scope": {"api_url_base": f"http://{KNOWN_API_HOST}"}}},
             config={},
         )
         with pytest.raises(ValueError, match="must use https"):
@@ -560,7 +564,7 @@ class TestEnvConfig:
                 "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
                 "mode": "pr_velocity",
             }],
-            "scope": {"api_url_base": "https://api.github.com", "orgs": ["file-org"]},
+            "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["file-org"]},
             "backfill": {"start_month": "2026-04"},
         }
         env_search = {
@@ -569,7 +573,7 @@ class TestEnvConfig:
                 "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
                 "mode": "pr_velocity",
             }],
-            "scope": {"api_url_base": "https://api.github.com", "orgs": ["env-org"]},
+            "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["env-org"]},
             "backfill": {"start_month": "2026-04"},
         }
         encoded = base64.b64encode(json.dumps(env_search).encode()).decode()

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -19,11 +19,13 @@ from tap_github_search.search_count_streams import (
     ConfigurablePrVelocityStream,
     ConfigurableSearchCountStream,
     NODES_THRESHOLD,
+    VALID_API_HOSTS,
     VALID_STREAM_MODES,
     _hours_between,
     _instance_from_api_base,
     _is_transient_graphql_failure,
     create_configurable_streams,
+    validate_scope,
     validate_stream_config,
 )
 
@@ -304,7 +306,7 @@ class TestNodeToRow:
         assert row["pr_number"] == 42
         assert row["author_login"] is None
         assert row["merged_by_login"] is None
-        assert row["label_names"] == ["bug"]   # nulls filtered, valid kept
+        assert row["label_names"] == '["bug"]'   # JSON-encoded; nulls filtered, valid kept
         assert row["outcome"] == "closed_unmerged"  # mergedAt None -> unmerged
         assert row["hours_to_close"] == 24.0
         assert row["is_ai_authored"] is False
@@ -387,3 +389,40 @@ class TestValidateStreamConfig:
             "name": "x", "query_template": "{org} {start} {end}", "mode": "pr-velocity",  # hyphen typo
         })
         assert any("Unknown mode" in e for e in errs)
+
+
+class TestValidateScope:
+    """SSRF allowlist on api_url_base. Defense-in-depth against scope misconfig."""
+
+    def test_accepts_known_hosts(self):
+        for host in VALID_API_HOSTS:
+            errs = validate_scope({"api_url_base": f"https://{host}/api/v3"})
+            assert errs == [], f"unexpected errors for known host {host}: {errs}"
+
+    def test_rejects_unknown_host(self):
+        errs = validate_scope({"api_url_base": "https://evil.example.com/api"})
+        assert any("not in allowlist" in e for e in errs)
+
+    def test_rejects_http_scheme(self):
+        errs = validate_scope({"api_url_base": "http://api.github.com"})
+        assert any("must use https" in e for e in errs)
+
+    def test_allows_missing_api_url_base(self):
+        # api_url_base is optional; partitions() falls back to https://api.github.com
+        assert validate_scope({}) == []
+
+    def test_create_configurable_streams_raises_on_bad_scope(self):
+        tap = _DummyTap()
+        config = {
+            "search": {
+                "streams": [{
+                    "name": "vel",
+                    "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+                    "mode": "pr_velocity",
+                }],
+                "scope": {"api_url_base": "https://evil.example.com", "orgs": ["x"]},
+                "backfill": {"start_month": "2026-04"},
+            }
+        }
+        with pytest.raises(ValueError, match="not in allowlist"):
+            create_configurable_streams(tap, config_override=config)

--- a/tap_github_search/tests/test_search_count_streams.py
+++ b/tap_github_search/tests/test_search_count_streams.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from datetime import date
 import logging
+from urllib.parse import urlparse
 from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from tap_github_search.github_hosts import DEFAULT_API_BASE_URL, VALID_API_HOSTS
 from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
     create_configurable_streams,
@@ -19,6 +21,12 @@ from tap_github_search.utils.date_utils import (
     month_to_date,
     get_last_complete_month,
     get_last_complete_month_date,
+)
+
+
+DEFAULT_API_HOST = urlparse(DEFAULT_API_BASE_URL).hostname or ""
+ENTERPRISE_API_HOSTS = tuple(
+    sorted(host for host in VALID_API_HOSTS if host != DEFAULT_API_HOST)
 )
 
 
@@ -40,7 +48,7 @@ def test_create_streams_from_search_namespace():
                     "query_template": "org:{org} type:issue is:open created:{start}..{end}",
                 }
             ],
-            "scope": {"api_url_base": "https://api.github.com", "orgs": ["Automattic"], "breakdown": "none"},
+            "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["example-org"], "breakdown": "none"},
             "backfill": {"start_month": "2025-01", "end_month": "2025-01"},
         }
     }
@@ -59,8 +67,8 @@ def test_query_template_substitution():
     mock_tap.config = {}
     stream = ConfigurableSearchCountStream(stream_config, mock_tap)
 
-    q = stream._build_search_query("WordPress", "2025-01-01", "2025-01-31", "issues")
-    assert q == "org:WordPress type:issue label:test created:2025-01-01..2025-01-31"
+    q = stream._build_search_query("example-org", "2025-01-01", "2025-01-31", "issues")
+    assert q == "org:example-org type:issue label:test created:2025-01-01..2025-01-31"
 
 
 # Authentication Tests
@@ -69,11 +77,12 @@ def test_ghe_token_validation_success(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.raise_for_status.return_value = None
     
-    manager = GHEPersonalTokenManager("token123", "https://github.enterprise.com/api/v3")
+    api_base_url = "https://github.example.invalid/api/v3"
+    manager = GHEPersonalTokenManager("token123", api_base_url)
     assert manager.is_valid_token() == True
     
     mock_get.assert_called_once_with(
-        url="https://github.enterprise.com/api/v3/user",
+        url=f"{api_base_url}/user",
         headers={"Authorization": "token token123"}
     )
 
@@ -85,7 +94,7 @@ def test_ghe_token_validation_failure(mock_get):
     mock_get.return_value.content = b"Bad credentials"
     mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError()
     
-    manager = GHEPersonalTokenManager("invalid_token", "https://github.enterprise.com/api/v3")
+    manager = GHEPersonalTokenManager("invalid_token", "https://github.example.invalid/api/v3")
     assert manager.is_valid_token() == False
 
 
@@ -93,7 +102,7 @@ def test_ghe_token_validation_failure(mock_get):
 def test_ghe_token_validation_connection_error(mock_get):
     mock_get.side_effect = requests.exceptions.ConnectionError()
     
-    manager = GHEPersonalTokenManager("token123", "https://github.enterprise.com/api/v3")
+    manager = GHEPersonalTokenManager("token123", "https://github.example.invalid/api/v3")
     assert manager.is_valid_token() == False
 
 
@@ -184,7 +193,7 @@ def test_configurable_stream_partitions_with_orgs():
         "search": {
             "scope": {
                 "orgs": ["TestOrg"],
-                "api_url_base": "https://api.github.com"
+                "api_url_base": DEFAULT_API_BASE_URL
             },
             "backfill": {
                 "start_month": "2024-01",
@@ -216,7 +225,7 @@ def test_configurable_stream_partitions_with_repos():
         "search": {
             "scope": {
                 "repos": ["TestOrg/test-repo"],
-                "api_url_base": "https://api.github.com"
+                "api_url_base": DEFAULT_API_BASE_URL
             },
             "backfill": {
                 "start_month": "2024-01", 
@@ -289,7 +298,7 @@ def test_range_passthrough(monkeypatch):
         return {"r1": 10}
 
     monkeypatch.setattr(s, "_get_repo_counts_from_nodes", fake_nodes)
-    out = s._search_with_auto_slicing("org:X is:issue created:2025-01-01..2025-01-31", "https://api.github.com")
+    out = s._search_with_auto_slicing("org:X is:issue created:2025-01-01..2025-01-31", DEFAULT_API_BASE_URL)
 
     assert calls["n"] == 1
     assert out == {"r1": 10}
@@ -308,7 +317,7 @@ def test_no_created_falls_back(monkeypatch):
         return {"rZ": 7}
 
     monkeypatch.setattr(s, "_get_repo_counts_from_nodes", fake_nodes)
-    out = s._search_with_auto_slicing("org:X is:issue label:foo", "https://api.github.com")
+    out = s._search_with_auto_slicing("org:X is:issue label:foo", DEFAULT_API_BASE_URL)
 
     assert calls["n"] == 1
     assert out == {"rZ": 7}
@@ -330,7 +339,7 @@ def test_repo_breakdown_batches_issuecount(monkeypatch):
     def fake_batch(queries, api):
         out = []
         for q in queries:
-            # q is like: repo:Automattic/rX rest...
+            # q is like: repo:example-org/rX rest...
             try:
                 repo_part = [p for p in q.split() if p.startswith("repo:")][0]
                 name = repo_part.split("/")[-1]
@@ -344,8 +353,8 @@ def test_repo_breakdown_batches_issuecount(monkeypatch):
     # Mock total count to trigger repo listing path
     monkeypatch.setattr(s, "_search_aggregate_count", lambda q, api: 2000)
 
-    q = "org:Automattic is:issue created:2025-01-01..2025-01-31"
-    out = s._search_with_repo_breakdown(q, "https://api.github.com")
+    q = "org:example-org is:issue created:2025-01-01..2025-01-31"
+    out = s._search_with_repo_breakdown(q, DEFAULT_API_BASE_URL)
 
     # Zero counts are filtered out by simplified implementation
     assert out == {"r1": 5, "r3": 3, "r4": 7, "r5": 1}
@@ -358,21 +367,29 @@ def test_repo_scoped_fast_path_issuecount(monkeypatch):
     s = _mk_stream()
 
     def fake_single(query, api):
-        assert query.startswith("repo:Automattic/calypso ")
+        assert query.startswith("repo:example-org/example-repo ")
         return 42
 
     monkeypatch.setattr(s, "_search_aggregate_count", fake_single)
 
-    q = "repo:Automattic/calypso is:issue created:2025-02-01..2025-02-28"
-    out = s._search_with_repo_breakdown(q, "https://api.github.com")
-    assert out == {"calypso": 42}
+    q = "repo:example-org/example-repo is:issue created:2025-02-01..2025-02-28"
+    out = s._search_with_repo_breakdown(q, DEFAULT_API_BASE_URL)
+    assert out == {"example-repo": 42}
 
 
-@pytest.mark.parametrize("api_url_base,expected_url", [
-    ("https://github.a8c.com/api/v3", "https://github.a8c.com/api/graphql"),
-    ("https://api.github.com", "https://api.github.com/graphql"),
-    ("https://github.tumblr.net/api/v3/", "https://github.tumblr.net/api/graphql"),
-])
+@pytest.mark.parametrize(
+    "api_url_base,expected_url",
+    [
+        (DEFAULT_API_BASE_URL, f"{DEFAULT_API_BASE_URL}/graphql"),
+        *[
+            (
+                f"https://{host}/api/v3",
+                f"https://{host}/api/graphql",
+            )
+            for host in ENTERPRISE_API_HOSTS
+        ],
+    ],
+)
 def test_graphql_url_strips_v3_for_ghes(monkeypatch, api_url_base, expected_url):
     s = _mk_stream()
     captured = {}
@@ -411,5 +428,5 @@ def test_null_nodes_skipped_in_repo_counts(monkeypatch):
 
     monkeypatch.setattr(s, "_make_graphql_request", lambda *args: mock_response)
 
-    result = s._get_repo_counts_from_nodes("org:Test type:pr", "https://api.github.com")
+    result = s._get_repo_counts_from_nodes("org:test-org type:pr", DEFAULT_API_BASE_URL)
     assert result == {"foo": 2, "bar": 1}

--- a/tap_github_search/tests/test_search_count_streams.py
+++ b/tap_github_search/tests/test_search_count_streams.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from datetime import date
-import os
-import types
 import logging
 from unittest.mock import Mock, patch
 import pytest
@@ -13,7 +11,6 @@ from tap_github_search.search_count_streams import (
     create_configurable_streams,
     validate_stream_config,
     SearchCountStreamBase,
-    BATCH_SIZE,
 )
 from tap_github_search.tap import TapGitHubSearch
 from tap_github_search.authenticator import GHEPersonalTokenManager
@@ -372,9 +369,9 @@ def test_repo_scoped_fast_path_issuecount(monkeypatch):
 
 
 @pytest.mark.parametrize("api_url_base,expected_url", [
-    ("https://github.enterprise.com/api/v3", "https://github.enterprise.com/api/graphql"),
+    ("https://github.a8c.com/api/v3", "https://github.a8c.com/api/graphql"),
     ("https://api.github.com", "https://api.github.com/graphql"),
-    ("https://github.enterprise.com/api/v3/", "https://github.enterprise.com/api/graphql"),
+    ("https://github.tumblr.net/api/v3/", "https://github.tumblr.net/api/graphql"),
 ])
 def test_graphql_url_strips_v3_for_ghes(monkeypatch, api_url_base, expected_url):
     s = _mk_stream()


### PR DESCRIPTION
## Purpose

Adds a new `ConfigurablePrVelocityStream` that emits **one row per closed PR** (not aggregated counts), enabling per-PR time-to-close and abandonment tracking.

Unlike the existing count streams that emit a single aggregate row per time slice, this stream surfaces individual PR-level fields: `pr_number`, `author_login`, `created_at`, `merged_at`, `closed_at`, `hours_to_close`, `outcome` (merged | closed_unmerged), `is_ai_authored`, `is_ai_reviewed`, `additions`, `deletions`, `changed_files`, review/comment/commit counts, and `label_names` (JSON-encoded string).

## How it works

- Activated by setting `"mode": "pr_velocity"` in a stream config entry. All existing stream configs without this field continue to use the count stream (fully backward compatible).
- Two new GraphQL fragments (`GRAPHQL_PR_VELOCITY` and `GRAPHQL_PR_IDS`) fetch PR metadata and IDs respectively.
- Adaptive granularity: fetches a whole month in one paginated pass when `issueCount <= 1000`; falls back to day-slicing for high-volume months.
- Reuses the existing transport, auth, pagination, and `is:closed`-aware date slicing from the base class.
- Cohort flags (AI-authored body markers, AI-reviewed commenter clauses, and empty-reviewer handling for instances without an AI-review bot) are driven entirely by config.

## Security

- SSRF allowlist (`VALID_API_HOSTS` = `api.github.com`, `github.a8c.com`, `github.tumblr.net`) enforced at **two layers**: `validate_scope` at config-load time, and `_extract_api_base_url_from_stream` in the authenticator (before any PAT is emitted to the wire). Adding a new host requires editing the source.

## Validation

- **Cluster scratch tests (4 runs, 36,693 rows total)** across both API surfaces:
  - `github_com / a8cteam51` (smoke): 134 rows
  - `a8c_ghe / Akismet` (GHES smoke): 60 rows
  - `github_com / Automattic` (production-scale): **17,722 rows** — exact match to GitHub's own `search.issueCount` for `org:Automattic type:pr is:closed closed:2026-02-01..2026-04-30`
  - `a8c_ghe / Automattic` (GHES production-scale): **18,777 rows** — exact match to GHE's own `search.issueCount` for the same window
- Data quality: zero PK collisions across `(instance, org_, repo, pr_number)` in any run; zero null/negative `hours_to_close`; zero outcome mismatches.
- Unit tests: **60/60 passing**.
- 502-resilience confirmed across multiple multi-month live pulls; env-tunable wall-time + retry budgets (`TAP_GITHUB_SEARCH_VELOCITY_OUTER_TRIES`, `..._MAX_WALL_SECONDS`).

## Backward compatibility

`create_configurable_streams()` instantiates `ConfigurablePrVelocityStream` only when a stream config has `"mode": "pr_velocity"`. All other configs continue to produce `ConfigurableSearchCountStream` instances unchanged. `mode` is whitelist-validated (typos rejected) so the count-stream fallback can't be triggered by accident.

## Deferred (separate PRs)

- Refactor transient-error handling into a `validate_response` override + `backoff_max_tries` on the shared base class. This also makes the existing count streams resilient to the same transient GraphQL INTERNAL errors they currently retry forever on. Out of scope for this PR's blast radius; will follow up.
- Resumable incremental state (per org+month bookmarks). The current full-window pattern works fine at the scales tested (40-min wall for 17k PRs); becomes worth doing if multi-org backfills go above ~2hr.
- A handful of P1/P2 follow-ups from the pre-merge review (markers/reviewer_clause length validation, defensive `KeyError` handling on malformed GraphQL payloads, strict wall-time enforcement, more adversarial SSRF tests). All filed as code comments / TODOs; none exploitable as-is.