### PR TITLE
Split capped PR velocity days by repository

### DIFF
--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -76,18 +76,6 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
     }
     """
 
-    GRAPHQL_ORG_REPOS: ClassVar[str] = """
-    query OrgRepos($org: String!, $after: String) {
-      organization(login: $org) {
-        repositories(first: 100, after: $after) {
-          pageInfo { hasNextPage endCursor }
-          nodes { name }
-        }
-      }
-      rateLimit { cost remaining }
-    }
-    """
-
     def __init__(self, stream_config: dict, tap):
         self.stream_config = stream_config
         self.query_template = stream_config["query_template"]
@@ -145,33 +133,13 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             after = page_info["endCursor"]
         return ids
 
-    def _list_all_repos_for_org(self, api_url_base: str, org: str) -> list[str]:
-        """List org repos without filtering, preserving org: search semantics."""
+    def _list_repos_for_pr_velocity(self, api_url_base: str, org: str) -> list[str]:
+        """Preserve org: search semantics by including archived and forked repos."""
         cache_key = (api_url_base, org)
         if cache_key in self._org_repo_cache:
             return self._org_repo_cache[cache_key]
 
-        repos: list[str] = []
-        after = None
-        has_next = True
-        while has_next:
-            resp = self._make_graphql_request(
-                self.GRAPHQL_ORG_REPOS,
-                {"org": org, "after": after},
-                api_url_base,
-            )
-            organization = resp.json()["data"].get("organization")
-            if organization is None:
-                raise RuntimeError(
-                    f"Could not list repositories for organization '{org}'"
-                )
-            data = organization["repositories"]
-            repos.extend(
-                repo["name"] for repo in data["nodes"] if repo and repo.get("name")
-            )
-            page_info = data["pageInfo"]
-            has_next = page_info["hasNextPage"]
-            after = page_info["endCursor"]
+        repos = self._list_repos_for_org(api_url_base, org, include_inactive=True)
         self._org_repo_cache[cache_key] = repos
         return repos
 
@@ -224,7 +192,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         repo_match = REPO_CAPTURE_RE.search(day_query)
         if repo_match:
             repo_label = f"{repo_match.group(1)}/{repo_match.group(2)}"
-            yield from self._iter_created_range_queries_for_capped_repo_day(
+            yield from self._iter_created_range_queries_for_capped_day(
                 day_query,
                 api_url_base,
                 repo_label,
@@ -242,7 +210,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             )
 
         org = org_match.group(1)
-        repos = self._list_all_repos_for_org(api_url_base, org)
+        repos = self._list_repos_for_pr_velocity(api_url_base, org)
         if not repos:
             raise RuntimeError(
                 "Could not split capped pr_velocity day query because "
@@ -265,7 +233,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         for repo, count in repo_counts.items():
             repo_query = self._build_repo_query(org, repo, rest_query)
             if count > NODES_THRESHOLD:
-                yield from self._iter_created_range_queries_for_capped_repo_day(
+                yield from self._iter_created_range_queries_for_capped_day(
                     repo_query,
                     api_url_base,
                     f"{org}/{repo}",
@@ -274,7 +242,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 continue
             yield repo_query
 
-    def _iter_created_range_queries_for_capped_repo_day(
+    def _iter_created_range_queries_for_capped_day(
         self,
         repo_query: str,
         api_url_base: str,
@@ -339,6 +307,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             yield query
             return
 
+        # No narrower date-only split exists for one repo on one created day.
         if start >= end:
             raise RuntimeError(
                 "pr_velocity repo created-day window exceeds GitHub search cap: "
@@ -375,6 +344,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
     ) -> None:
         if actual == expected:
             return
+        # Historical counts should be stable; near-live windows may fail loudly
+        # if GitHub search counts change between parent and child queries.
         raise RuntimeError(
             f"pr_velocity {split_name} split did not preserve GitHub search "
             f"count: parent matched {expected}, split matched {actual}. "

--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
-from typing import Any, ClassVar, Iterable
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, ClassVar, Iterable, Iterator
 
 from singer_sdk import typing as th
 from singer_sdk.helpers.types import Context
@@ -12,16 +12,16 @@ from singer_sdk.helpers.types import Context
 from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
     NODES_THRESHOLD,
-    ORG_PATTERN,
-    ORG_REPLACEMENT_PATTERN,
-    REPO_PATTERN,
     SearchCountStreamBase,
 )
 
 DEFAULT_INSTANCE = "github_com"
 CLOSED_CAPTURE_RE = re.compile(r"closed:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})")
-CREATED_CAPTURE_RE = re.compile(r"created:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})")
-CREATED_SEARCH_START_DATE = datetime(2008, 1, 1)
+CREATED_QUALIFIER_RE = re.compile(r"(?:^|\s)-?created:")
+ORG_CAPTURE_RE = re.compile(r"(?:^|\s)org:([^\s]+)")
+ORG_QUALIFIER_RE = re.compile(r"(?:^|\s)org:[^\s]+\s*")
+REPO_CAPTURE_RE = re.compile(r"(?:^|\s)repo:([^\s/]+)/([^\s]+)")
+CREATED_SEARCH_START_DATE = date(2008, 1, 1)
 
 
 def _hours_between(created: str | None, closed: str | None) -> float | None:
@@ -95,6 +95,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         self.name = stream_config["name"]
         self.stream_type = stream_config.get("stream_type", stream_config.get("name", "pr_velocity"))
         self.tap = tap
+        self._org_repo_cache: dict[tuple[str, str], list[str]] = {}
         SearchCountStreamBase.__init__(self, tap=tap, name=self.name, schema=self.get_schema())
 
     @classmethod
@@ -145,6 +146,11 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         return ids
 
     def _list_all_repos_for_org(self, api_url_base: str, org: str) -> list[str]:
+        """List org repos without filtering, preserving org: search semantics."""
+        cache_key = (api_url_base, org)
+        if cache_key in self._org_repo_cache:
+            return self._org_repo_cache[cache_key]
+
         repos: list[str] = []
         after = None
         has_next = True
@@ -166,19 +172,47 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             page_info = data["pageInfo"]
             has_next = page_info["hasNextPage"]
             after = page_info["endCursor"]
+        self._org_repo_cache[cache_key] = repos
         return repos
 
-    def _iter_day_queries(self, query: str):
+    def _iter_day_queries(self, query: str) -> Iterator[str]:
         match = CLOSED_CAPTURE_RE.search(query)
         if not match:
             yield query
             return
-        current = datetime.strptime(match.group(1), "%Y-%m-%d")
-        end = datetime.strptime(match.group(2), "%Y-%m-%d")
+        current = date.fromisoformat(match.group(1))
+        end = date.fromisoformat(match.group(2))
         while current <= end:
-            day = current.strftime("%Y-%m-%d")
+            day = current.isoformat()
             yield query.replace(match.group(0), f"closed:{day}..{day}")
             current += timedelta(days=1)
+
+    def _iter_processable_queries(
+        self,
+        query: str,
+        api_url_base: str,
+        org: str,
+    ) -> Iterator[str]:
+        month_count = self._search_aggregate_count(query, api_url_base)
+        if month_count == 0:
+            return
+        if month_count <= NODES_THRESHOLD:
+            yield query
+            return
+
+        for day_query in self._iter_day_queries(query):
+            day_count = self._search_aggregate_count(day_query, api_url_base)
+            if day_count == 0:
+                continue
+            if day_count <= NODES_THRESHOLD:
+                yield day_query
+                continue
+            yield from self._iter_repo_queries_for_capped_day(
+                day_query,
+                api_url_base,
+                org,
+                day_count,
+            )
 
     def _iter_repo_queries_for_capped_day(
         self,
@@ -186,8 +220,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         api_url_base: str,
         org: str,
         day_count: int,
-    ):
-        repo_match = REPO_PATTERN.search(day_query)
+    ) -> Iterator[str]:
+        repo_match = REPO_CAPTURE_RE.search(day_query)
         if repo_match:
             repo_label = f"{repo_match.group(1)}/{repo_match.group(2)}"
             yield from self._iter_created_range_queries_for_capped_repo_day(
@@ -198,7 +232,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             )
             return
 
-        if not ORG_PATTERN.search(day_query):
+        org_match = ORG_CAPTURE_RE.search(day_query)
+        if not org_match:
             raise RuntimeError(
                 "pr_velocity repo-scoped day window exceeds GitHub search cap: "
                 f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
@@ -206,6 +241,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 f"an organization. Query: {day_query}"
             )
 
+        org = org_match.group(1)
         repos = self._list_all_repos_for_org(api_url_base, org)
         if not repos:
             raise RuntimeError(
@@ -213,12 +249,18 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 f"org '{org}' has no repositories"
             )
 
-        rest_query = ORG_REPLACEMENT_PATTERN.sub("", day_query).strip()
+        rest_query = ORG_QUALIFIER_RE.sub(" ", day_query).strip()
         repo_counts = self._get_repo_counts_via_batching(
             repos,
             org,
             rest_query,
             api_url_base,
+        )
+        self._ensure_split_count_matches(
+            "repo",
+            day_query,
+            expected=day_count,
+            actual=sum(repo_counts.values()),
         )
         for repo, count in repo_counts.items():
             repo_query = self._build_repo_query(org, repo, rest_query)
@@ -238,8 +280,8 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         api_url_base: str,
         repo_label: str,
         repo_day_count: int,
-    ):
-        if CREATED_CAPTURE_RE.search(repo_query):
+    ) -> Iterator[str]:
+        if CREATED_QUALIFIER_RE.search(repo_query):
             raise RuntimeError(
                 "pr_velocity created-date window exceeds GitHub search cap: "
                 f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
@@ -254,10 +296,22 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                 f"because it is not scoped to a single closed day. Query: {repo_query}"
             )
 
-        closed_day = datetime.strptime(match.group(1), "%Y-%m-%d")
+        closed_day = date.fromisoformat(match.group(1))
         self.logger.info(
             "Repo-scoped pr_velocity day exceeded search cap; splitting by "
             f"created date for repo '{repo_label}'"
+        )
+        created_query = self._append_created_range(
+            repo_query,
+            CREATED_SEARCH_START_DATE,
+            closed_day,
+        )
+        created_count = self._search_aggregate_count(created_query, api_url_base)
+        self._ensure_split_count_matches(
+            "created-date",
+            created_query,
+            expected=repo_day_count,
+            actual=created_count,
         )
         yield from self._iter_created_range_queries(
             repo_query,
@@ -265,7 +319,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             repo_label,
             CREATED_SEARCH_START_DATE,
             closed_day,
-            repo_day_count,
+            created_count,
         )
 
     def _iter_created_range_queries(
@@ -273,10 +327,10 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         base_query: str,
         api_url_base: str,
         repo_label: str,
-        start: datetime,
-        end: datetime,
+        start: date,
+        end: date,
         count: int,
-    ):
+    ) -> Iterator[str]:
         if count == 0:
             return
 
@@ -296,32 +350,35 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         midpoint = start + timedelta(days=(end - start).days // 2)
         right_start = midpoint + timedelta(days=1)
 
-        left_query = self._append_created_range(base_query, start, midpoint)
-        left_count = self._search_aggregate_count(left_query, api_url_base)
-        yield from self._iter_created_range_queries(
-            base_query,
-            api_url_base,
-            repo_label,
-            start,
-            midpoint,
-            left_count,
-        )
+        for child_start, child_end in ((start, midpoint), (right_start, end)):
+            child_query = self._append_created_range(base_query, child_start, child_end)
+            child_count = self._search_aggregate_count(child_query, api_url_base)
+            yield from self._iter_created_range_queries(
+                base_query,
+                api_url_base,
+                repo_label,
+                child_start,
+                child_end,
+                child_count,
+            )
 
-        right_query = self._append_created_range(base_query, right_start, end)
-        right_count = self._search_aggregate_count(right_query, api_url_base)
-        yield from self._iter_created_range_queries(
-            base_query,
-            api_url_base,
-            repo_label,
-            right_start,
-            end,
-            right_count,
-        )
+    def _append_created_range(self, query: str, start: date, end: date) -> str:
+        return f"{query} created:{start.isoformat()}..{end.isoformat()}"
 
-    def _append_created_range(self, query: str, start: datetime, end: datetime) -> str:
-        return (
-            f"{query} created:{start.strftime('%Y-%m-%d')}.."
-            f"{end.strftime('%Y-%m-%d')}"
+    def _ensure_split_count_matches(
+        self,
+        split_name: str,
+        query: str,
+        *,
+        expected: int,
+        actual: int,
+    ) -> None:
+        if actual == expected:
+            return
+        raise RuntimeError(
+            f"pr_velocity {split_name} split did not preserve GitHub search "
+            f"count: parent matched {expected}, split matched {actual}. "
+            f"Query: {query}"
         )
 
     def _node_to_row(self, node: dict, instance: str, org: str, month: str, now: str) -> dict:
@@ -366,42 +423,14 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             query = partition["search_query"]
             api_url_base = partition["api_url_base"]
 
-            month_count = self._search_aggregate_count(query, api_url_base)
-            if month_count == 0:
-                continue
-            if month_count <= NODES_THRESHOLD:
-                yield from self._process_window(query, api_url_base, instance, org, month, now, markers, reviewer)
-            else:
-                for day_query in self._iter_day_queries(query):
-                    day_count = self._search_aggregate_count(day_query, api_url_base)
-                    if day_count == 0:
-                        continue
-                    if day_count > NODES_THRESHOLD:
-                        repo_queries = self._iter_repo_queries_for_capped_day(
-                            day_query,
-                            api_url_base,
-                            org,
-                            day_count,
-                        )
-                        for repo_query in repo_queries:
-                            yield from self._process_window(
-                                repo_query,
-                                api_url_base,
-                                instance,
-                                org,
-                                month,
-                                now,
-                                markers,
-                                reviewer,
-                            )
-                        continue
-                    yield from self._process_window(
-                        day_query,
-                        api_url_base,
-                        instance,
-                        org,
-                        month,
-                        now,
-                        markers,
-                        reviewer,
-                    )
+            for window_query in self._iter_processable_queries(query, api_url_base, org):
+                yield from self._process_window(
+                    window_query,
+                    api_url_base,
+                    instance,
+                    org,
+                    month,
+                    now,
+                    markers,
+                    reviewer,
+                )

--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -12,6 +12,8 @@ from singer_sdk.helpers.types import Context
 from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
     NODES_THRESHOLD,
+    ORG_PATTERN,
+    ORG_REPLACEMENT_PATTERN,
     SearchCountStreamBase,
 )
 
@@ -66,6 +68,18 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
       search(query: $q, type: ISSUE, first: 50, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes { ... on PullRequest { number repository { nameWithOwner } } }
+      }
+      rateLimit { cost remaining }
+    }
+    """
+
+    GRAPHQL_ORG_REPOS: ClassVar[str] = """
+    query OrgRepos($org: String!, $after: String) {
+      organization(login: $org) {
+        repositories(first: 100, after: $after) {
+          pageInfo { hasNextPage endCursor }
+          nodes { name }
+        }
       }
       rateLimit { cost remaining }
     }
@@ -127,6 +141,30 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             after = page_info["endCursor"]
         return ids
 
+    def _list_all_repos_for_org(self, api_url_base: str, org: str) -> list[str]:
+        repos: list[str] = []
+        after = None
+        has_next = True
+        while has_next:
+            resp = self._make_graphql_request(
+                self.GRAPHQL_ORG_REPOS,
+                {"org": org, "after": after},
+                api_url_base,
+            )
+            organization = resp.json()["data"].get("organization")
+            if organization is None:
+                raise RuntimeError(
+                    f"Could not list repositories for organization '{org}'"
+                )
+            data = organization["repositories"]
+            repos.extend(
+                repo["name"] for repo in data["nodes"] if repo and repo.get("name")
+            )
+            page_info = data["pageInfo"]
+            has_next = page_info["hasNextPage"]
+            after = page_info["endCursor"]
+        return repos
+
     def _iter_day_queries(self, query: str):
         match = CLOSED_CAPTURE_RE.search(query)
         if not match:
@@ -138,6 +176,45 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             day = current.strftime("%Y-%m-%d")
             yield query.replace(match.group(0), f"closed:{day}..{day}")
             current += timedelta(days=1)
+
+    def _iter_repo_queries_for_capped_day(
+        self,
+        day_query: str,
+        api_url_base: str,
+        org: str,
+    ):
+        if not ORG_PATTERN.search(day_query):
+            raise RuntimeError(
+                "pr_velocity repo-scoped day window exceeds GitHub search cap: "
+                f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
+                "results per query, and this query is already scoped below "
+                f"an organization. Query: {day_query}"
+            )
+
+        repos = self._list_all_repos_for_org(api_url_base, org)
+        if not repos:
+            raise RuntimeError(
+                "Could not split capped pr_velocity day query because "
+                f"org '{org}' has no repositories"
+            )
+
+        rest_query = ORG_REPLACEMENT_PATTERN.sub("", day_query).strip()
+        repo_counts = self._get_repo_counts_via_batching(
+            repos,
+            org,
+            rest_query,
+            api_url_base,
+        )
+        for repo, count in repo_counts.items():
+            repo_query = self._build_repo_query(org, repo, rest_query)
+            if count > NODES_THRESHOLD:
+                raise RuntimeError(
+                    "pr_velocity repo-scoped day window exceeds GitHub search cap: "
+                    f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
+                    "results per query, "
+                    f"but repo '{org}/{repo}' matched {count}. Query: {repo_query}"
+                )
+            yield repo_query
 
     def _node_to_row(self, node: dict, instance: str, org: str, month: str, now: str) -> dict:
         repo_name = node["repository"].get("name") or node["repository"]["nameWithOwner"].split("/")[-1]
@@ -189,12 +266,33 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             else:
                 for day_query in self._iter_day_queries(query):
                     day_count = self._search_aggregate_count(day_query, api_url_base)
+                    if day_count == 0:
+                        continue
                     if day_count > NODES_THRESHOLD:
-                        raise RuntimeError(
-                            "pr_velocity day window exceeds GitHub search cap: "
-                            f"GitHub GraphQL search returns at most {NODES_THRESHOLD} results per query, "
-                            f"but this day matched {day_count}. "
-                            "Narrow the configured query, for example by splitting it into repo-scoped "
-                            f"or otherwise more selective queries. Query: {day_query}"
+                        repo_queries = self._iter_repo_queries_for_capped_day(
+                            day_query,
+                            api_url_base,
+                            org,
                         )
-                    yield from self._process_window(day_query, api_url_base, instance, org, month, now, markers, reviewer)
+                        for repo_query in repo_queries:
+                            yield from self._process_window(
+                                repo_query,
+                                api_url_base,
+                                instance,
+                                org,
+                                month,
+                                now,
+                                markers,
+                                reviewer,
+                            )
+                        continue
+                    yield from self._process_window(
+                        day_query,
+                        api_url_base,
+                        instance,
+                        org,
+                        month,
+                        now,
+                        markers,
+                        reviewer,
+                    )

--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -14,11 +14,14 @@ from tap_github_search.search_count_streams import (
     NODES_THRESHOLD,
     ORG_PATTERN,
     ORG_REPLACEMENT_PATTERN,
+    REPO_PATTERN,
     SearchCountStreamBase,
 )
 
 DEFAULT_INSTANCE = "github_com"
 CLOSED_CAPTURE_RE = re.compile(r"closed:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})")
+CREATED_CAPTURE_RE = re.compile(r"created:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})")
+CREATED_SEARCH_START_DATE = datetime(2008, 1, 1)
 
 
 def _hours_between(created: str | None, closed: str | None) -> float | None:
@@ -182,7 +185,19 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         day_query: str,
         api_url_base: str,
         org: str,
+        day_count: int,
     ):
+        repo_match = REPO_PATTERN.search(day_query)
+        if repo_match:
+            repo_label = f"{repo_match.group(1)}/{repo_match.group(2)}"
+            yield from self._iter_created_range_queries_for_capped_repo_day(
+                day_query,
+                api_url_base,
+                repo_label,
+                day_count,
+            )
+            return
+
         if not ORG_PATTERN.search(day_query):
             raise RuntimeError(
                 "pr_velocity repo-scoped day window exceeds GitHub search cap: "
@@ -208,13 +223,106 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         for repo, count in repo_counts.items():
             repo_query = self._build_repo_query(org, repo, rest_query)
             if count > NODES_THRESHOLD:
-                raise RuntimeError(
-                    "pr_velocity repo-scoped day window exceeds GitHub search cap: "
-                    f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
-                    "results per query, "
-                    f"but repo '{org}/{repo}' matched {count}. Query: {repo_query}"
+                yield from self._iter_created_range_queries_for_capped_repo_day(
+                    repo_query,
+                    api_url_base,
+                    f"{org}/{repo}",
+                    count,
                 )
+                continue
             yield repo_query
+
+    def _iter_created_range_queries_for_capped_repo_day(
+        self,
+        repo_query: str,
+        api_url_base: str,
+        repo_label: str,
+        repo_day_count: int,
+    ):
+        if CREATED_CAPTURE_RE.search(repo_query):
+            raise RuntimeError(
+                "pr_velocity created-date window exceeds GitHub search cap: "
+                f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
+                "results per query, and this query is already scoped by "
+                f"created date. Query: {repo_query}"
+            )
+
+        match = CLOSED_CAPTURE_RE.search(repo_query)
+        if not match or match.group(1) != match.group(2):
+            raise RuntimeError(
+                "Could not split capped pr_velocity repo query by created date "
+                f"because it is not scoped to a single closed day. Query: {repo_query}"
+            )
+
+        closed_day = datetime.strptime(match.group(1), "%Y-%m-%d")
+        self.logger.info(
+            "Repo-scoped pr_velocity day exceeded search cap; splitting by "
+            f"created date for repo '{repo_label}'"
+        )
+        yield from self._iter_created_range_queries(
+            repo_query,
+            api_url_base,
+            repo_label,
+            CREATED_SEARCH_START_DATE,
+            closed_day,
+            repo_day_count,
+        )
+
+    def _iter_created_range_queries(
+        self,
+        base_query: str,
+        api_url_base: str,
+        repo_label: str,
+        start: datetime,
+        end: datetime,
+        count: int,
+    ):
+        if count == 0:
+            return
+
+        query = self._append_created_range(base_query, start, end)
+        if count <= NODES_THRESHOLD:
+            yield query
+            return
+
+        if start >= end:
+            raise RuntimeError(
+                "pr_velocity repo created-day window exceeds GitHub search cap: "
+                f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
+                "results per query, "
+                f"but repo '{repo_label}' matched {count}. Query: {query}"
+            )
+
+        midpoint = start + timedelta(days=(end - start).days // 2)
+        right_start = midpoint + timedelta(days=1)
+
+        left_query = self._append_created_range(base_query, start, midpoint)
+        left_count = self._search_aggregate_count(left_query, api_url_base)
+        yield from self._iter_created_range_queries(
+            base_query,
+            api_url_base,
+            repo_label,
+            start,
+            midpoint,
+            left_count,
+        )
+
+        right_query = self._append_created_range(base_query, right_start, end)
+        right_count = self._search_aggregate_count(right_query, api_url_base)
+        yield from self._iter_created_range_queries(
+            base_query,
+            api_url_base,
+            repo_label,
+            right_start,
+            end,
+            right_count,
+        )
+
+    def _append_created_range(self, query: str, start: datetime, end: datetime) -> str:
+        return (
+            f"{query} created:{start.strftime('%Y-%m-%d')}.."
+            f"{end.strftime('%Y-%m-%d')}"
+        )
 
     def _node_to_row(self, node: dict, instance: str, org: str, month: str, now: str) -> dict:
         repo_name = node["repository"].get("name") or node["repository"]["nameWithOwner"].split("/")[-1]
@@ -273,6 +381,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
                             day_query,
                             api_url_base,
                             org,
+                            day_count,
                         )
                         for repo_query in repo_queries:
                             yield from self._process_window(

--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -21,6 +21,8 @@ CREATED_QUALIFIER_RE = re.compile(r"(?:^|\s)-?created:")
 ORG_CAPTURE_RE = re.compile(r"(?:^|\s)org:([^\s]+)")
 ORG_QUALIFIER_RE = re.compile(r"(?:^|\s)org:[^\s]+\s*")
 REPO_CAPTURE_RE = re.compile(r"(?:^|\s)repo:([^\s/]+)/([^\s]+)")
+# GitHub launched in 2008, so no PR can predate this; it is a safe lower bound
+# for the created-date range that captures every PR closed on a given day.
 CREATED_SEARCH_START_DATE = date(2008, 1, 1)
 
 
@@ -159,7 +161,6 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         self,
         query: str,
         api_url_base: str,
-        org: str,
     ) -> Iterator[str]:
         month_count = self._search_aggregate_count(query, api_url_base)
         if month_count == 0:
@@ -178,7 +179,6 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             yield from self._iter_repo_queries_for_capped_day(
                 day_query,
                 api_url_base,
-                org,
                 day_count,
             )
 
@@ -186,7 +186,6 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         self,
         day_query: str,
         api_url_base: str,
-        org: str,
         day_count: int,
     ) -> Iterator[str]:
         repo_match = REPO_CAPTURE_RE.search(day_query)
@@ -203,10 +202,10 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         org_match = ORG_CAPTURE_RE.search(day_query)
         if not org_match:
             raise RuntimeError(
-                "pr_velocity repo-scoped day window exceeds GitHub search cap: "
+                "pr_velocity day window exceeds GitHub search cap: "
                 f"GitHub GraphQL search returns at most {NODES_THRESHOLD} "
-                "results per query, and this query is already scoped below "
-                f"an organization. Query: {day_query}"
+                "results per query, but this query has no org: or repo: "
+                f"qualifier to split on. Query: {day_query}"
             )
 
         org = org_match.group(1)
@@ -394,7 +393,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             query = partition["search_query"]
             api_url_base = partition["api_url_base"]
 
-            for window_query in self._iter_processable_queries(query, api_url_base, org):
+            for window_query in self._iter_processable_queries(query, api_url_base):
                 yield from self._process_window(
                     window_query,
                     api_url_base,

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -353,8 +353,14 @@ class SearchCountStreamBase(GitHubGraphqlStream):
             current = slice_end + timedelta(days=1)
         return dict(repo_counts)
 
-    def _list_repos_for_org(self, api_url_base: str, org: str) -> list[str]:
-        """List active repositories for an organization."""
+    def _list_repos_for_org(
+        self,
+        api_url_base: str,
+        org: str,
+        *,
+        include_inactive: bool = False,
+    ) -> list[str]:
+        """List repositories for an organization."""
         query = """
         query($org:String!, $after:String){
           organization(login:$org){
@@ -374,11 +380,17 @@ class SearchCountStreamBase(GitHubGraphqlStream):
         
         while True:
             resp = self._make_graphql_request(query, {"org": org, "after": after}, api_url_base)
-            data = resp.json()["data"]["organization"]["repositories"]
+            organization = resp.json()["data"].get("organization")
+            if organization is None:
+                raise RuntimeError(f"Could not list repositories for organization '{org}'")
+            data = organization["repositories"]
             
-            # Filter out forks and archived repos
-            active_repos = self._filter_active_repos(data["nodes"])
-            names.extend(active_repos)
+            if include_inactive:
+                names.extend(
+                    repo["name"] for repo in data["nodes"] if repo and repo.get("name")
+                )
+            else:
+                names.extend(self._filter_active_repos(data["nodes"]))
             
             if not data["pageInfo"]["hasNextPage"]:
                 break

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -234,7 +234,7 @@ def test_collect_pr_ids_uses_end_cursor_for_next_page():
     assert fake_request.call_args_list[1][0][1]["after"] == "cursor-one"
 
 
-def test_list_all_repos_for_org_uses_end_cursor_for_next_page():
+def test_pr_velocity_repo_listing_uses_end_cursor_for_next_page():
     stream = _mk_velocity()
     with patch.object(
         stream,
@@ -250,7 +250,7 @@ def test_list_all_repos_for_org_uses_end_cursor_for_next_page():
             ),
         ],
     ) as fake_request:
-        repos = stream._list_all_repos_for_org(DEFAULT_API_BASE_URL, "example-org")
+        repos = stream._list_repos_for_pr_velocity(DEFAULT_API_BASE_URL, "example-org")
 
     assert repos == ["repo-one", "repo-two"]
     assert fake_request.call_args_list[0][0][1]["after"] is None
@@ -306,7 +306,7 @@ def test_get_records_repo_slices_when_single_org_day_exceeds_search_cap():
     with patch.object(stream, "_search_aggregate_count", side_effect=count), \
          patch.object(
              stream,
-             "_list_all_repos_for_org",
+             "_list_repos_for_pr_velocity",
              return_value=["repo-one", "repo-two"],
          ), \
          patch.object(
@@ -342,7 +342,7 @@ def test_get_records_fails_when_repo_counts_do_not_cover_capped_day():
         return 0
 
     with patch.object(stream, "_search_aggregate_count", side_effect=count), \
-         patch.object(stream, "_list_all_repos_for_org", return_value=["repo-one"]), \
+         patch.object(stream, "_list_repos_for_pr_velocity", return_value=["repo-one"]), \
          patch.object(stream, "_get_repo_counts_via_batching", return_value={"repo-one": 1}), \
          pytest.raises(RuntimeError, match="repo split did not preserve GitHub search count"):
         list(stream.get_records(_velocity_context(
@@ -370,7 +370,7 @@ def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
          patch.object(stream, "_search_aggregate_count", side_effect=count), \
          patch.object(
              stream,
-             "_list_all_repos_for_org",
+             "_list_repos_for_pr_velocity",
              return_value=["big-repo"],
          ), \
          patch.object(

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import base64
-from datetime import datetime
+from datetime import date, datetime
 import json
 import logging
 from unittest.mock import patch
+
+import pytest
 
 from tap_github_search.pr_velocity_stream import ConfigurablePrVelocityStream
 from tap_github_search.search_count_streams import (
@@ -82,6 +84,19 @@ def _mk_velocity(*, markers=None, reviewer="", instance="github_com"):
         }
     }
     return stream
+
+
+def _velocity_context(search_query):
+    return {
+        "org": "example-org",
+        "month": "2026-04",
+        "search_query": search_query,
+        "api_url_base": DEFAULT_API_BASE_URL,
+    }
+
+
+def _processed_queries(fake_process):
+    return [call.args[0] for call in fake_process.call_args_list]
 
 
 def test_dispatches_pr_velocity_mode():
@@ -256,12 +271,9 @@ def test_get_records_emits_json_serializable_synced_at():
 
     with patch.object(stream, "_search_aggregate_count", return_value=1), \
          patch.object(stream, "_iter_pr_nodes", return_value=iter([node])):
-        row = next(stream.get_records({
-            "org": "example-org",
-            "month": "2026-04",
-            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
-            "api_url_base": DEFAULT_API_BASE_URL,
-        }))
+        row = next(stream.get_records(_velocity_context(
+            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+        )))
 
     assert isinstance(row["synced_at"], str)
     assert row["synced_at"].endswith("Z")
@@ -273,15 +285,12 @@ def test_get_records_day_slices_when_month_exceeds_search_cap():
     stream = _mk_velocity()
     with patch.object(stream, "_search_aggregate_count", side_effect=[NODES_THRESHOLD + 1] + [5] * 30), \
          patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records({
-            "org": "example-org",
-            "month": "2026-04",
-            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
-            "api_url_base": DEFAULT_API_BASE_URL,
-        }))
+        list(stream.get_records(_velocity_context(
+            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+        )))
 
     assert fake_process.call_count == 30
-    assert "closed:2026-04-01..2026-04-01" in fake_process.call_args_list[0][0][0]
+    assert "closed:2026-04-01..2026-04-01" in _processed_queries(fake_process)[0]
 
 
 def test_get_records_repo_slices_when_single_org_day_exceeds_search_cap():
@@ -303,29 +312,50 @@ def test_get_records_repo_slices_when_single_org_day_exceeds_search_cap():
          patch.object(
              stream,
              "_get_repo_counts_via_batching",
-             return_value={"repo-one": 800, "repo-two": 200},
-         ), \
+             return_value={"repo-one": 800, "repo-two": 201},
+         ) as fake_repo_counts, \
          patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records({
-            "org": "example-org",
-            "month": "2026-04",
-            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
-            "api_url_base": DEFAULT_API_BASE_URL,
-        }))
+        list(stream.get_records(_velocity_context(
+            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+        )))
 
-    assert fake_process.call_count == 2
-    assert fake_process.call_args_list[0][0][0] == (
-        "repo:example-org/repo-one type:pr is:closed closed:2026-04-01..2026-04-01"
+    fake_repo_counts.assert_called_once_with(
+        ["repo-one", "repo-two"],
+        "example-org",
+        "type:pr is:closed closed:2026-04-01..2026-04-01",
+        DEFAULT_API_BASE_URL,
     )
-    assert fake_process.call_args_list[1][0][0] == (
-        "repo:example-org/repo-two type:pr is:closed closed:2026-04-01..2026-04-01"
-    )
+    assert _processed_queries(fake_process) == [
+        "repo:example-org/repo-one type:pr is:closed closed:2026-04-01..2026-04-01",
+        "repo:example-org/repo-two type:pr is:closed closed:2026-04-01..2026-04-01",
+    ]
+
+
+def test_get_records_fails_when_repo_counts_do_not_cover_capped_day():
+    stream = _mk_velocity()
+
+    def count(query, _api_url_base):
+        if "closed:2026-04-01..2026-04-30" in query:
+            return NODES_THRESHOLD + 1
+        if "closed:2026-04-01..2026-04-01" in query:
+            return NODES_THRESHOLD + 1
+        return 0
+
+    with patch.object(stream, "_search_aggregate_count", side_effect=count), \
+         patch.object(stream, "_list_all_repos_for_org", return_value=["repo-one"]), \
+         patch.object(stream, "_get_repo_counts_via_batching", return_value={"repo-one": 1}), \
+         pytest.raises(RuntimeError, match="repo split did not preserve GitHub search count"):
+        list(stream.get_records(_velocity_context(
+            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+        )))
 
 
 def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
     stream = _mk_velocity()
 
     def count(query, _api_url_base):
+        if "created:2026-03-31..2026-04-01" in query:
+            return NODES_THRESHOLD + 1
         if "created:2026-03-31..2026-03-31" in query:
             return 700
         if "created:2026-04-01..2026-04-01" in query:
@@ -336,7 +366,7 @@ def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
             return NODES_THRESHOLD + 1
         return 0
 
-    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 3, 31)), \
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", date(2026, 3, 31)), \
          patch.object(stream, "_search_aggregate_count", side_effect=count), \
          patch.object(
              stream,
@@ -349,78 +379,103 @@ def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
              return_value={"big-repo": NODES_THRESHOLD + 1},
          ), \
          patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records({
-            "org": "example-org",
-            "month": "2026-04",
-            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
-            "api_url_base": DEFAULT_API_BASE_URL,
-        }))
+        list(stream.get_records(_velocity_context(
+            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+        )))
 
-    assert fake_process.call_count == 2
-    assert fake_process.call_args_list[0][0][0] == (
+    assert _processed_queries(fake_process) == [
         "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31"
-    )
-    assert fake_process.call_args_list[1][0][0] == (
+        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31",
         "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01"
-    )
+        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01",
+    ]
 
 
 def test_get_records_created_slices_when_repo_scoped_day_exceeds_search_cap():
     stream = _mk_velocity()
 
     def count(query, _api_url_base):
+        if "created:2026-03-31..2026-04-01" in query:
+            return NODES_THRESHOLD + 1
         if "created:2026-03-31..2026-03-31" in query:
             return 700
         if "created:2026-04-01..2026-04-01" in query:
             return 500
         return NODES_THRESHOLD + 1
 
-    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 3, 31)), \
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", date(2026, 3, 31)), \
          patch.object(stream, "_search_aggregate_count", side_effect=count), \
          patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records({
-            "org": "example-org",
-            "month": "2026-04",
-            "search_query": (
+        list(stream.get_records(_velocity_context(
+            (
                 "repo:example-org/big-repo type:pr is:closed "
                 "closed:2026-04-01..2026-04-01"
-            ),
-            "api_url_base": DEFAULT_API_BASE_URL,
-        }))
+            )
+        )))
 
-    assert fake_process.call_count == 2
-    assert fake_process.call_args_list[0][0][0] == (
+    assert _processed_queries(fake_process) == [
         "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31"
-    )
-    assert fake_process.call_args_list[1][0][0] == (
+        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31",
         "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01"
+        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01",
+    ]
+
+
+def test_iter_created_range_queries_recurses_until_leaf_counts_fit_cap():
+    stream = _mk_velocity()
+    base_query = (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-04..2026-04-04"
     )
+
+    def count(query, _api_url_base):
+        if "created:2026-04-01..2026-04-02" in query:
+            return NODES_THRESHOLD + 1
+        if "created:2026-04-01..2026-04-01" in query:
+            return 600
+        if "created:2026-04-02..2026-04-02" in query:
+            return 500
+        return 0
+
+    with patch.object(stream, "_search_aggregate_count", side_effect=count):
+        queries = list(stream._iter_created_range_queries(
+            base_query,
+            DEFAULT_API_BASE_URL,
+            "example-org/big-repo",
+            date(2026, 4, 1),
+            date(2026, 4, 4),
+            NODES_THRESHOLD + 1,
+        ))
+
+    assert queries == [
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-04..2026-04-04 created:2026-04-01..2026-04-01",
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-04..2026-04-04 created:2026-04-02..2026-04-02",
+    ]
+
+
+def test_get_records_fails_when_query_already_has_created_qualifier():
+    stream = _mk_velocity()
+
+    with patch.object(stream, "_search_aggregate_count", return_value=NODES_THRESHOLD + 1), \
+         pytest.raises(RuntimeError, match="already scoped by created date"):
+        list(stream.get_records(_velocity_context(
+            "repo:example-org/big-repo type:pr is:closed "
+            "closed:2026-04-01..2026-04-01 created:>=2026-03-01"
+        )))
 
 
 def test_get_records_fails_when_created_day_exceeds_search_cap():
     stream = _mk_velocity()
 
-    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 4, 1)), \
-         patch.object(stream, "_search_aggregate_count", return_value=NODES_THRESHOLD + 1):
-        try:
-            list(stream.get_records({
-                "org": "example-org",
-                "month": "2026-04",
-                "search_query": (
-                    "repo:example-org/big-repo type:pr is:closed "
-                    "closed:2026-04-01..2026-04-01"
-                ),
-                "api_url_base": DEFAULT_API_BASE_URL,
-            }))
-        except RuntimeError as exc:
-            assert "repo created-day window exceeds GitHub search cap" in str(exc)
-            assert "GitHub GraphQL search returns at most" in str(exc)
-        else:
-            raise AssertionError("expected over-cap created-day window to fail")
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", date(2026, 4, 1)), \
+         patch.object(stream, "_search_aggregate_count", return_value=NODES_THRESHOLD + 1), \
+         pytest.raises(RuntimeError, match="repo created-day window exceeds GitHub search cap"):
+        list(stream.get_records(_velocity_context(
+            "repo:example-org/big-repo type:pr is:closed "
+            "closed:2026-04-01..2026-04-01"
+        )))
 
 
 def test_b64_config_overrides_existing_search_config(monkeypatch):

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -45,6 +45,23 @@ class _GraphqlResponse:
         return self.payload
 
 
+class _RepoResponse:
+    def __init__(self, *, nodes, has_next=False, end_cursor=None):
+        self.payload = {
+            "data": {
+                "organization": {
+                    "repositories": {
+                        "nodes": nodes,
+                        "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+                    }
+                }
+            }
+        }
+
+    def json(self):
+        return self.payload
+
+
 def _mk_velocity(*, markers=None, reviewer="", instance="github_com"):
     stream_config = {
         "name": "pr_velocity",
@@ -202,6 +219,29 @@ def test_collect_pr_ids_uses_end_cursor_for_next_page():
     assert fake_request.call_args_list[1][0][1]["after"] == "cursor-one"
 
 
+def test_list_all_repos_for_org_uses_end_cursor_for_next_page():
+    stream = _mk_velocity()
+    with patch.object(
+        stream,
+        "_make_graphql_request",
+        side_effect=[
+            _RepoResponse(
+                nodes=[{"name": "repo-one"}], has_next=True, end_cursor="cursor-one"
+            ),
+            _RepoResponse(
+                nodes=[{"name": "repo-two"}],
+                has_next=False,
+                end_cursor=None,
+            ),
+        ],
+    ) as fake_request:
+        repos = stream._list_all_repos_for_org(DEFAULT_API_BASE_URL, "example-org")
+
+    assert repos == ["repo-one", "repo-two"]
+    assert fake_request.call_args_list[0][0][1]["after"] is None
+    assert fake_request.call_args_list[1][0][1]["after"] == "cursor-one"
+
+
 def test_get_records_emits_json_serializable_synced_at():
     stream = _mk_velocity()
     node = {
@@ -244,20 +284,64 @@ def test_get_records_day_slices_when_month_exceeds_search_cap():
     assert "closed:2026-04-01..2026-04-01" in fake_process.call_args_list[0][0][0]
 
 
-def test_get_records_fails_when_single_day_exceeds_search_cap():
+def test_get_records_repo_slices_when_single_org_day_exceeds_search_cap():
     stream = _mk_velocity()
-    with patch.object(stream, "_search_aggregate_count", side_effect=[NODES_THRESHOLD + 1, NODES_THRESHOLD + 1]):
+
+    def count(query, _api_url_base):
+        if "closed:2026-04-01..2026-04-30" in query:
+            return NODES_THRESHOLD + 1
+        if "closed:2026-04-01..2026-04-01" in query:
+            return NODES_THRESHOLD + 1
+        return 0
+
+    with patch.object(stream, "_search_aggregate_count", side_effect=count), \
+         patch.object(
+             stream,
+             "_list_all_repos_for_org",
+             return_value=["repo-one", "repo-two"],
+         ), \
+         patch.object(
+             stream,
+             "_get_repo_counts_via_batching",
+             return_value={"repo-one": 800, "repo-two": 200},
+         ), \
+         patch.object(stream, "_process_window", return_value=[]) as fake_process:
+        list(stream.get_records({
+            "org": "example-org",
+            "month": "2026-04",
+            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+            "api_url_base": DEFAULT_API_BASE_URL,
+        }))
+
+    assert fake_process.call_count == 2
+    assert fake_process.call_args_list[0][0][0] == (
+        "repo:example-org/repo-one type:pr is:closed closed:2026-04-01..2026-04-01"
+    )
+    assert fake_process.call_args_list[1][0][0] == (
+        "repo:example-org/repo-two type:pr is:closed closed:2026-04-01..2026-04-01"
+    )
+
+
+def test_get_records_fails_when_repo_scoped_day_exceeds_search_cap():
+    stream = _mk_velocity()
+    with patch.object(
+        stream,
+        "_search_aggregate_count",
+        side_effect=[NODES_THRESHOLD + 1, NODES_THRESHOLD + 1],
+    ):
         try:
             list(stream.get_records({
                 "org": "example-org",
                 "month": "2026-04",
-                "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+                "search_query": (
+                    "repo:example-org/big-repo type:pr is:closed "
+                    "closed:2026-04-01..2026-04-30"
+                ),
                 "api_url_base": DEFAULT_API_BASE_URL,
             }))
         except RuntimeError as exc:
-            assert "exceeds GitHub search cap" in str(exc)
+            assert "repo-scoped day window exceeds GitHub search cap" in str(exc)
             assert "GitHub GraphQL search returns at most" in str(exc)
-            assert "repo-scoped" in str(exc)
         else:
             raise AssertionError("expected over-cap day window to fail")
 

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -322,28 +322,105 @@ def test_get_records_repo_slices_when_single_org_day_exceeds_search_cap():
     )
 
 
-def test_get_records_fails_when_repo_scoped_day_exceeds_search_cap():
+def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
     stream = _mk_velocity()
-    with patch.object(
-        stream,
-        "_search_aggregate_count",
-        side_effect=[NODES_THRESHOLD + 1, NODES_THRESHOLD + 1],
-    ):
+
+    def count(query, _api_url_base):
+        if "created:2026-03-31..2026-03-31" in query:
+            return 700
+        if "created:2026-04-01..2026-04-01" in query:
+            return 500
+        if "closed:2026-04-01..2026-04-30" in query:
+            return NODES_THRESHOLD + 1
+        if "closed:2026-04-01..2026-04-01" in query:
+            return NODES_THRESHOLD + 1
+        return 0
+
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 3, 31)), \
+         patch.object(stream, "_search_aggregate_count", side_effect=count), \
+         patch.object(
+             stream,
+             "_list_all_repos_for_org",
+             return_value=["big-repo"],
+         ), \
+         patch.object(
+             stream,
+             "_get_repo_counts_via_batching",
+             return_value={"big-repo": NODES_THRESHOLD + 1},
+         ), \
+         patch.object(stream, "_process_window", return_value=[]) as fake_process:
+        list(stream.get_records({
+            "org": "example-org",
+            "month": "2026-04",
+            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+            "api_url_base": DEFAULT_API_BASE_URL,
+        }))
+
+    assert fake_process.call_count == 2
+    assert fake_process.call_args_list[0][0][0] == (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31"
+    )
+    assert fake_process.call_args_list[1][0][0] == (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01"
+    )
+
+
+def test_get_records_created_slices_when_repo_scoped_day_exceeds_search_cap():
+    stream = _mk_velocity()
+
+    def count(query, _api_url_base):
+        if "created:2026-03-31..2026-03-31" in query:
+            return 700
+        if "created:2026-04-01..2026-04-01" in query:
+            return 500
+        return NODES_THRESHOLD + 1
+
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 3, 31)), \
+         patch.object(stream, "_search_aggregate_count", side_effect=count), \
+         patch.object(stream, "_process_window", return_value=[]) as fake_process:
+        list(stream.get_records({
+            "org": "example-org",
+            "month": "2026-04",
+            "search_query": (
+                "repo:example-org/big-repo type:pr is:closed "
+                "closed:2026-04-01..2026-04-01"
+            ),
+            "api_url_base": DEFAULT_API_BASE_URL,
+        }))
+
+    assert fake_process.call_count == 2
+    assert fake_process.call_args_list[0][0][0] == (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31"
+    )
+    assert fake_process.call_args_list[1][0][0] == (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01"
+    )
+
+
+def test_get_records_fails_when_created_day_exceeds_search_cap():
+    stream = _mk_velocity()
+
+    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", datetime(2026, 4, 1)), \
+         patch.object(stream, "_search_aggregate_count", return_value=NODES_THRESHOLD + 1):
         try:
             list(stream.get_records({
                 "org": "example-org",
                 "month": "2026-04",
                 "search_query": (
                     "repo:example-org/big-repo type:pr is:closed "
-                    "closed:2026-04-01..2026-04-30"
+                    "closed:2026-04-01..2026-04-01"
                 ),
                 "api_url_base": DEFAULT_API_BASE_URL,
             }))
         except RuntimeError as exc:
-            assert "repo-scoped day window exceeds GitHub search cap" in str(exc)
+            assert "repo created-day window exceeds GitHub search cap" in str(exc)
             assert "GitHub GraphQL search returns at most" in str(exc)
         else:
-            raise AssertionError("expected over-cap day window to fail")
+            raise AssertionError("expected over-cap created-day window to fail")
 
 
 def test_b64_config_overrides_existing_search_config(monkeypatch):

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from contextlib import ExitStack
 from datetime import date, datetime
 import json
 import logging
@@ -350,7 +351,14 @@ def test_get_records_fails_when_repo_counts_do_not_cover_capped_day():
         )))
 
 
-def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
+@pytest.mark.parametrize("search_query", [
+    "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+    (
+        "repo:example-org/big-repo type:pr is:closed "
+        "closed:2026-04-01..2026-04-01"
+    ),
+])
+def test_get_records_created_slices_when_repo_day_exceeds_search_cap(search_query):
     stream = _mk_velocity()
 
     def count(query, _api_url_base):
@@ -366,52 +374,33 @@ def test_get_records_created_slices_when_org_repo_day_exceeds_search_cap():
             return NODES_THRESHOLD + 1
         return 0
 
-    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", date(2026, 3, 31)), \
-         patch.object(stream, "_search_aggregate_count", side_effect=count), \
-         patch.object(
-             stream,
-             "_list_repos_for_pr_velocity",
-             return_value=["big-repo"],
-         ), \
-         patch.object(
-             stream,
-             "_get_repo_counts_via_batching",
-             return_value={"big-repo": NODES_THRESHOLD + 1},
-         ), \
-         patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records(_velocity_context(
-            "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
-        )))
-
-    assert _processed_queries(fake_process) == [
-        "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-03-31..2026-03-31",
-        "repo:example-org/big-repo type:pr is:closed "
-        "closed:2026-04-01..2026-04-01 created:2026-04-01..2026-04-01",
-    ]
-
-
-def test_get_records_created_slices_when_repo_scoped_day_exceeds_search_cap():
-    stream = _mk_velocity()
-
-    def count(query, _api_url_base):
-        if "created:2026-03-31..2026-04-01" in query:
-            return NODES_THRESHOLD + 1
-        if "created:2026-03-31..2026-03-31" in query:
-            return 700
-        if "created:2026-04-01..2026-04-01" in query:
-            return 500
-        return NODES_THRESHOLD + 1
-
-    with patch("tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE", date(2026, 3, 31)), \
-         patch.object(stream, "_search_aggregate_count", side_effect=count), \
-         patch.object(stream, "_process_window", return_value=[]) as fake_process:
-        list(stream.get_records(_velocity_context(
-            (
-                "repo:example-org/big-repo type:pr is:closed "
-                "closed:2026-04-01..2026-04-01"
-            )
-        )))
+    with ExitStack() as stack:
+        stack.enter_context(patch(
+            "tap_github_search.pr_velocity_stream.CREATED_SEARCH_START_DATE",
+            date(2026, 3, 31),
+        ))
+        stack.enter_context(patch.object(
+            stream,
+            "_search_aggregate_count",
+            side_effect=count,
+        ))
+        if search_query.startswith("org:"):
+            stack.enter_context(patch.object(
+                stream,
+                "_list_repos_for_pr_velocity",
+                return_value=["big-repo"],
+            ))
+            stack.enter_context(patch.object(
+                stream,
+                "_get_repo_counts_via_batching",
+                return_value={"big-repo": NODES_THRESHOLD + 1},
+            ))
+        fake_process = stack.enter_context(patch.object(
+            stream,
+            "_process_window",
+            return_value=[],
+        ))
+        list(stream.get_records(_velocity_context(search_query)))
 
     assert _processed_queries(fake_process) == [
         "repo:example-org/big-repo type:pr is:closed "


### PR DESCRIPTION
## Summary
- add a progressive fallback for `pr_velocity` queries that still exceed GitHub GraphQL Search's 1,000-result node cap after day slicing
- split capped windows by repository and, when needed, by created-date ranges
- keep split count reconciliation fail-fast so incomplete child windows are not accepted silently
- cover repo listing pagination, capped window fanout, created-date bisection, and reconciliation failures

## Rationale
Day slicing alone is not always selective enough for high-volume repositories or organizations. A direct day-to-created-date fallback is smaller, but it can still hit the cap when many PRs share the same created and closed day. The repository step keeps leaf queries smaller while the reconciliation checks preserve fail-fast behavior.

## Testing
- `poetry run pytest tap_github_search/tests`
