### PR TITLE
Add max_pr_age_days window to pr_velocity queries

### DIFF
--- a/tap_github_search/pr_velocity_stream.py
+++ b/tap_github_search/pr_velocity_stream.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, ClassVar, Iterable
 
 from singer_sdk import typing as th
@@ -77,6 +77,7 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
         self.stream_description = stream_config.get("description", f"PR velocity stream: {stream_config['name']}")
         self.name = stream_config["name"]
         self.stream_type = stream_config.get("stream_type", stream_config.get("name", "pr_velocity"))
+        self.max_pr_age_days = stream_config.get("max_pr_age_days")
         self.tap = tap
         SearchCountStreamBase.__init__(self, tap=tap, name=self.name, schema=self.get_schema())
 
@@ -180,6 +181,11 @@ class ConfigurablePrVelocityStream(ConfigurableSearchCountStream):
             month = partition["month"]
             query = partition["search_query"]
             api_url_base = partition["api_url_base"]
+            if self.max_pr_age_days:
+                # Exclude long-stale PRs (e.g. bulk backlog cleanups) so they
+                # don't skew velocity stats or blow the 1000-result search cap.
+                floor = date.fromisoformat(f"{month}-01") - timedelta(days=self.max_pr_age_days)
+                query += f" created:>={floor.isoformat()}"
 
             month_count = self._search_aggregate_count(query, api_url_base)
             if month_count == 0:

--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -499,6 +499,7 @@ def create_configurable_streams(tap, config_override: dict | None = None) -> lis
                 "mode": sd.get("mode"),
                 "markers": sd.get("markers", []),
                 "reviewer_clause": sd.get("reviewer_clause", ""),
+                "max_pr_age_days": sd.get("max_pr_age_days"),
             }
             errors = validate_stream_config(sc)
             if errors:

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -86,6 +86,24 @@ def test_dispatches_pr_velocity_mode():
     assert type(streams[0]) is ConfigurablePrVelocityStream
 
 
+def test_create_configurable_streams_passes_max_pr_age_days_through():
+    tap = _DummyTap()
+    config = {
+        "search": {
+            "streams": [{
+                "name": "pr_velocity",
+                "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
+                "mode": "pr_velocity",
+                "max_pr_age_days": 365,
+            }],
+            "scope": {"api_url_base": DEFAULT_API_BASE_URL, "orgs": ["example-org"]},
+            "backfill": {"start_month": "2026-04"},
+        }
+    }
+    streams = create_configurable_streams(tap, config_override=config)
+    assert streams[0].max_pr_age_days == 365
+
+
 def test_process_window_sets_minimal_fields_and_ai_flags():
     stream = _mk_velocity(
         markers=['"AI marker"', "assistant-marker"],

--- a/tap_github_search/tests/test_pr_velocity_stream.py
+++ b/tap_github_search/tests/test_pr_velocity_stream.py
@@ -45,13 +45,14 @@ class _GraphqlResponse:
         return self.payload
 
 
-def _mk_velocity(*, markers=None, reviewer="", instance="github_com"):
+def _mk_velocity(*, markers=None, reviewer="", instance="github_com", max_pr_age_days=None):
     stream_config = {
         "name": "pr_velocity",
         "query_template": "org:{org} type:pr is:closed closed:{start}..{end}",
         "mode": "pr_velocity",
         "markers": markers or [],
         "reviewer_clause": reviewer,
+        "max_pr_age_days": max_pr_age_days,
     }
     stream = ConfigurablePrVelocityStream(stream_config, _DummyTap())
     stream._search_cfg = {
@@ -242,6 +243,39 @@ def test_get_records_day_slices_when_month_exceeds_search_cap():
 
     assert fake_process.call_count == 30
     assert "closed:2026-04-01..2026-04-01" in fake_process.call_args_list[0][0][0]
+
+
+def test_get_records_appends_created_floor_when_max_pr_age_days_set():
+    stream = _mk_velocity(max_pr_age_days=365)
+    with patch.object(stream, "_search_aggregate_count", side_effect=[NODES_THRESHOLD + 1] + [5] * 30), \
+         patch.object(stream, "_process_window", return_value=[]) as fake_process:
+        list(stream.get_records({
+            "org": "example-org",
+            "month": "2026-04",
+            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+            "api_url_base": DEFAULT_API_BASE_URL,
+        }))
+
+    # Floor anchored to the close month start; day slices carry the same floor.
+    assert fake_process.call_args_list[0][0][0] == (
+        "org:example-org type:pr is:closed closed:2026-04-01..2026-04-01 created:>=2025-04-01"
+    )
+
+
+def test_get_records_leaves_query_unchanged_without_max_pr_age_days():
+    stream = _mk_velocity()
+    with patch.object(stream, "_search_aggregate_count", return_value=5), \
+         patch.object(stream, "_process_window", return_value=[]) as fake_process:
+        list(stream.get_records({
+            "org": "example-org",
+            "month": "2026-04",
+            "search_query": "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30",
+            "api_url_base": DEFAULT_API_BASE_URL,
+        }))
+
+    assert fake_process.call_args_list[0][0][0] == (
+        "org:example-org type:pr is:closed closed:2026-04-01..2026-04-30"
+    )
 
 
 def test_get_records_fails_when_single_day_exceeds_search_cap():


### PR DESCRIPTION
## Summary
- add an optional `max_pr_age_days` setting to the `pr_velocity` stream config
- when set, each month's search query gets a `created:>=` floor anchored to the close month start, excluding PRs that were open longer than the window

## Rationale
Replaces #20. High-volume orgs occasionally bulk-close large backlogs of long-stale PRs. Those closures can push a single day past GitHub Search's 1,000-result cap, and their multi-year time-to-close values skew velocity stats (mean/p50/p90, abandonment) regardless of the cap. Bounding the metric to PRs resolved within the window fixes both problems at once: capped days drop well under the limit, so plain day slicing stays sufficient, and normal months lose only a negligible fraction of rows.

## Testing
- `python -m pytest tap_github_search/tests` (37 passed)
- validated end-to-end against a previously-capped backfill window; bulk-cleanup days that exceeded the cap now process cleanly with day slicing alone