### PR TITLE
Retry GitHub's transient server-side GraphQL errors

### DIFF
--- a/tap_github_search/search_count_streams.py
+++ b/tap_github_search/search_count_streams.py
@@ -11,6 +11,7 @@ import requests
 from collections import Counter
 
 from singer_sdk import typing as th
+from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.helpers.types import Context
 
 from tap_github.client import GitHubGraphqlStream
@@ -61,6 +62,23 @@ class SearchCountStreamBase(GitHubGraphqlStream):
     def _build_graphql_payload(self, query_template: str, variables: dict[str, Any]) -> dict[str, Any]:
         """Build a standardized GraphQL payload."""
         return {"query": query_template, "variables": variables}
+
+    def validate_response(self, response: requests.Response) -> None:
+        """Retry GitHub's transient server-side GraphQL failures.
+
+        github.com search occasionally returns 200 with an errors array like
+        "Something went wrong while executing your query ... Please include
+        `<request-id>` ...". Upstream tap_github treats any GraphQL error as
+        fatal; reclassify only this transient case as retriable so backoff
+        retries it. Everything else stays fatal.
+        """
+        if response.status_code == 200:
+            errors = (response.json().get("errors") or []) if response.content else []
+            if errors and all(
+                "Something went wrong while executing your query" in (e.get("message") or "") for e in errors
+            ):
+                raise RetriableAPIError(f"GitHub transient GraphQL error: {errors[0]['message']}", response)
+        super().validate_response(response)
 
     def _make_graphql_request(self, query_template: str, variables: dict[str, Any], api_url_base: str):
         """Make a GraphQL request with standardized payload building."""

--- a/tap_github_search/tests/test_search_count_streams.py
+++ b/tap_github_search/tests/test_search_count_streams.py
@@ -7,6 +7,7 @@ import logging
 from unittest.mock import Mock, patch
 import pytest
 import requests
+from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 
 from tap_github_search.search_count_streams import (
     ConfigurableSearchCountStream,
@@ -416,3 +417,39 @@ def test_null_nodes_skipped_in_repo_counts(monkeypatch):
 
     result = s._get_repo_counts_from_nodes("org:Test type:pr", "https://api.github.com")
     assert result == {"foo": 2, "bar": 1}
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.content = b"x"
+        self.headers = {}
+        self.url = "https://api.github.com/graphql"
+        self.reason = "OK"
+
+    def json(self):
+        return self.payload
+
+
+def test_validate_response_retries_transient_graphql_error():
+    stream = _mk_stream()
+    resp = _FakeResponse({"errors": [{"message": (
+        "Something went wrong while executing your query on 2026-06-11T02:59:54Z. "
+        "Please include `E2D4:EBE9B` when reporting this issue."
+    )}]})
+    with pytest.raises(RetriableAPIError, match="transient"):
+        stream.validate_response(resp)
+
+
+def test_validate_response_keeps_real_graphql_errors_fatal():
+    stream = _mk_stream()
+    resp = _FakeResponse({"errors": [{"type": "FORBIDDEN", "message": "org forbids access"}]})
+    with pytest.raises(FatalAPIError, match="Graphql error"):
+        stream.validate_response(resp)
+
+
+def test_validate_response_passes_clean_response():
+    stream = _mk_stream()
+    resp = _FakeResponse({"data": {"search": {"issueCount": 1}}})
+    stream.validate_response(resp)


### PR DESCRIPTION
## Summary
- reclassify GitHub's transient "Something went wrong while executing your query" GraphQL error (HTTP 200 + errors array, no error type) as `RetriableAPIError` so the existing five-try exponential backoff retries it
- all other GraphQL errors keep failing fast as before

## Rationale
A long node-fetching backfill makes thousands of search requests; GitHub's search backend occasionally throws this transient error and the upstream client treats any GraphQL error as fatal, killing runs that cannot resume mid-stream. A flake retried two seconds later virtually always succeeds; anything persistently broken still fails after ~30s of backoff.

## Testing
- `python -m pytest tap_github_search/tests` (40 passed) — covers transient→retriable, real errors stay fatal, clean responses pass